### PR TITLE
test: add tests for URL deep-linking and keyboard shortcut

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -168,17 +168,26 @@ function updateHash() {
   history.replaceState(null, '', qs ? '#' + qs : location.pathname + location.search);
 }
 
-function readHash() {
-  if (!location.hash) return;
-  const params = new URLSearchParams(location.hash.slice(1));
+// Reads current URL hash and applies filter/search state.
+// Called on initial page load and on hashchange (e.g. browser back/forward).
+function applyHashState() {
+  const params = location.hash ? new URLSearchParams(location.hash.slice(1)) : new URLSearchParams();
   const filter = params.get('filter');
   const search = params.get('search');
-  if (filter) activeFilter = filter;
-  if (search) {
-    searchVal = search.toLowerCase();
-    document.getElementById('search-input').value = search;
-  }
+
+  activeFilter = filter || 'all';
+  searchVal    = search ? search.toLowerCase() : '';
+  document.getElementById('search-input').value = search || '';
+
+  document.querySelectorAll('.filter-btn').forEach(b =>
+    b.classList.toggle('active', b.dataset.filter === activeFilter)
+  );
+  render();
 }
+
+// history.replaceState (used by updateHash) does NOT fire hashchange,
+// so this only triggers on external hash changes (back/forward, manual edits).
+window.addEventListener('hashchange', applyHashState);
 
 /* ── FILTERS & VIEW ───────────────────────────────────────────── */
 function setFilter(f) {
@@ -233,15 +242,10 @@ document.addEventListener('keydown', e => {
 
 /* ── INIT ─────────────────────────────────────────────────────── */
 buildFilters();
-readHash();
-// Sync filter button active state after reading hash
-document.querySelectorAll('.filter-btn').forEach(b =>
-  b.classList.toggle('active', b.dataset.filter === activeFilter)
-);
 // Show platform-appropriate keyboard shortcut hint
 (function () {
   const isMac = /Mac|iPhone|iPad|iPod/.test(navigator.platform);
   const el = document.getElementById('search-shortcut');
   if (el) el.textContent = isMac ? '⌘K' : 'Ctrl+K';
 }());
-render();
+applyHashState();

--- a/tests/cheatsheet.spec.js
+++ b/tests/cheatsheet.spec.js
@@ -227,6 +227,101 @@ test.describe('Modal', () => {
   });
 });
 
+/* ── URL DEEP-LINKING ──────────────────────────────────────────── */
+test.describe('URL deep-linking', () => {
+  test('applying a category filter updates the URL hash', async ({ page }) => {
+    await page.locator('.filter-btn', { hasText: 'Action' }).click();
+    expect(page.url()).toContain('filter=Action');
+  });
+
+  test('typing in search updates the URL hash', async ({ page }) => {
+    await page.locator('#search-input').fill('click');
+    expect(page.url()).toContain('search=click');
+  });
+
+  test('both filter and search are reflected in the URL hash', async ({ page }) => {
+    await page.locator('.filter-btn', { hasText: 'Action' }).click();
+    await page.locator('#search-input').fill('click');
+    const url = page.url();
+    expect(url).toContain('filter=Action');
+    expect(url).toContain('search=click');
+  });
+
+  test('resetting to All removes filter from URL hash', async ({ page }) => {
+    await page.locator('.filter-btn', { hasText: 'Action' }).click();
+    await page.locator('.filter-btn', { hasText: 'All' }).click();
+    expect(page.url()).not.toContain('filter=');
+  });
+
+  test('clearing search removes search from URL hash', async ({ page }) => {
+    await page.locator('#search-input').fill('click');
+    await page.locator('#search-input').clear();
+    expect(page.url()).not.toContain('search=');
+  });
+
+  test('loading with #filter hash pre-applies the category filter', async ({ page }) => {
+    const totalCount = await page.locator('.tile').count();
+
+    await page.goto('/#filter=Action');
+    await expect(page.locator('.filter-btn', { hasText: 'Action' })).toHaveClass(/active/);
+    const filteredCount = await page.locator('.tile').count();
+    expect(filteredCount).toBeGreaterThan(0);
+    expect(filteredCount).toBeLessThan(totalCount);
+  });
+
+  test('loading with #filter=beginner hash applies the Start Here filter', async ({ page }) => {
+    const totalCount = await page.locator('.tile').count();
+
+    await page.goto('/#filter=beginner');
+    await expect(page.locator('.filter-btn', { hasText: 'Start Here' })).toHaveClass(/active/);
+    const filteredCount = await page.locator('.tile').count();
+    expect(filteredCount).toBeGreaterThan(0);
+    expect(filteredCount).toBeLessThan(totalCount);
+  });
+
+  test('loading with #search hash pre-populates the search input and filters tiles', async ({ page }) => {
+    const totalCount = await page.locator('.tile').count();
+
+    await page.goto('/#search=click');
+    const inputValue = await page.locator('#search-input').inputValue();
+    expect(inputValue).toBe('click');
+    const filteredCount = await page.locator('.tile').count();
+    expect(filteredCount).toBeGreaterThan(0);
+    expect(filteredCount).toBeLessThan(totalCount);
+  });
+
+  test('loading with both #filter and #search applies both simultaneously', async ({ page }) => {
+    await page.goto('/#filter=Action&search=click');
+    await expect(page.locator('.filter-btn', { hasText: 'Action' })).toHaveClass(/active/);
+    const inputValue = await page.locator('#search-input').inputValue();
+    expect(inputValue).toBe('click');
+    expect(await page.locator('.tile').count()).toBeGreaterThan(0);
+  });
+});
+
+/* ── KEYBOARD SHORTCUTS ────────────────────────────────────────── */
+test.describe('Keyboard shortcuts', () => {
+  test('search shortcut hint badge is visible in the search bar', async ({ page }) => {
+    await expect(page.locator('#search-shortcut')).toBeVisible();
+    const text = await page.locator('#search-shortcut').innerText();
+    expect(['⌘K', 'Ctrl+K']).toContain(text);
+  });
+
+  test('Ctrl+K focuses the search input', async ({ page }) => {
+    await page.locator('body').click(); // ensure focus is away from search
+    await page.keyboard.press('Control+k');
+    const isFocused = await page.locator('#search-input').evaluate(
+      el => document.activeElement === el
+    );
+    expect(isFocused).toBe(true);
+  });
+
+  test('search input has an accessible aria-label', async ({ page }) => {
+    const label = await page.locator('#search-input').getAttribute('aria-label');
+    expect(label).toBeTruthy();
+  });
+});
+
 /* ── MOBILE ────────────────────────────────────────────────────── */
 test.describe('Mobile', () => {
   test('filter bar is scrollable when filters overflow', async ({ page, isMobile }) => {


### PR DESCRIPTION
- URL deep-linking (8 tests): verifies hash updates on filter/search changes, hash removal on reset, and hash-on-load restoration for filter, beginner, search, and combined states
- Keyboard shortcuts (3 tests): verifies Ctrl+K focuses search, shortcut hint badge is visible with correct label, and aria-label

Also improves the hash implementation: readHash() replaced with applyHashState() which is also registered as a hashchange listener, enabling back/forward browser navigation to restore state correctly.

https://claude.ai/code/session_01DCNpiST4oMDFgVBmtSh1Ww