### PR TITLE
Add auto-updating meta bar with version, date, and command count

### DIFF
--- a/index.html
+++ b/index.html
@@ -10,6 +10,12 @@
 
 <header>🎭 Playwright Commands Dashboard 🎭</header>
 
+<div class="meta-bar">
+  <span class="meta-pill"><span class="meta-dot" style="background:#22c55e"></span>Playwright <strong id="pw-version">v1.60.0</strong></span>
+  <span class="meta-pill"><span class="meta-dot" style="background:#38bdf8"></span>Updated <strong id="last-updated">2026-06-06</strong></span>
+  <span class="meta-pill"><span class="meta-dot" style="background:#a855f7"></span><strong id="cmd-count">0</strong>&nbsp;commands</span>
+</div>
+
 <div class="container">
   <div class="search-wrap">
     <input type="text" id="search-input" placeholder="Search commands, descriptions, tips..." aria-label="Search commands">

--- a/js/app.js
+++ b/js/app.js
@@ -256,6 +256,42 @@ document.getElementById('btn-copy').addEventListener('click', copyCode);
 
 buildFilters();
 
+/* ── META BAR ─────────────────────────────────────────────────── */
+// Command count comes from the data; version and last-updated date are
+// fetched live so they never go stale. Both fetches fail gracefully,
+// leaving the fallback values already present in the HTML.
+const GITHUB_REPO = 'youvegotnigel/playwright-commands-cheat-sheet';
+
+(function initMetaBar() {
+  const countEl = document.getElementById('cmd-count');
+  if (countEl) countEl.textContent = allItems.length;
+
+  // Playwright version — read from package.json's declared dependency
+  fetch('./package.json')
+    .then(r => (r.ok ? r.json() : Promise.reject(r.status)))
+    .then(pkg => {
+      const dep =
+        pkg.devDependencies?.['@playwright/test'] ??
+        pkg.dependencies?.['@playwright/test'];
+      if (!dep) return;
+      const clean = dep.replace(/^[\^~>=<\s]+/, ''); // strip range prefix
+      const el = document.getElementById('pw-version');
+      if (el) el.textContent = 'v' + clean;
+    })
+    .catch(() => {});
+
+  // Last updated — date of the most recent commit on master
+  fetch(`https://api.github.com/repos/${GITHUB_REPO}/commits/master`)
+    .then(r => (r.ok ? r.json() : Promise.reject(r.status)))
+    .then(commit => {
+      const iso = commit?.commit?.committer?.date;
+      if (!iso) return;
+      const el = document.getElementById('last-updated');
+      if (el) el.textContent = iso.slice(0, 10); // YYYY-MM-DD
+    })
+    .catch(() => {});
+}());
+
 // Show platform-appropriate keyboard shortcut hint
 (function () {
   const isMac = /Mac|iPhone|iPad|iPod/.test(

--- a/style.css
+++ b/style.css
@@ -2,6 +2,17 @@
 body { font-family: Arial, sans-serif; margin: 0; background: #0f172a; color: #e2e8f0; }
 header { padding: 16px; text-align: center; font-size: 36px; font-weight: bold; background: #020617; color: #2ead33; }
 
+.meta-bar { display: flex; justify-content: center; align-items: center; gap: 10px; flex-wrap: wrap; padding: 12px 16px; background: #020617; border-top: 1px solid #1e293b; }
+.meta-pill {
+  display: inline-flex; align-items: center; gap: 7px;
+  padding: 6px 14px; border-radius: 999px;
+  background: rgba(255,255,255,0.06); color: #cbd5e1;
+  font-size: 13px; font-weight: 500; transition: background 0.15s;
+}
+.meta-pill:hover { background: rgba(255,255,255,0.12); }
+.meta-pill strong { color: #fff; font-weight: 600; }
+.meta-dot { width: 9px; height: 9px; border-radius: 50%; flex-shrink: 0; }
+
 .container { padding: 15px; max-width: 1200px; margin: auto; }
 
 .search-wrap { position: relative; margin-bottom: 12px; }


### PR DESCRIPTION
Show Playwright version, last-updated date, and total command count as pill badges below the header. Version is read from package.json and the date from the GitHub API for the latest master commit, so both stay current with no manual edits; the command count derives from the data. Fetches fail gracefully, falling back to the values in the HTML.