### PR TITLE
Add popular commands - track opens via Supabase, badge + sort

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -131,6 +131,30 @@ All fetches fail gracefully, falling back to the hardcoded values in `index.html
   in the Supabase SQL editor (cannot be done from client/anon key).
 - The Edge Function slug **must** be exactly `increment-visitor`.
 
+## Popular commands (Supabase)
+
+Reuses the visitor-counter infra to count command **opens** and surface the most
+popular ones.
+
+- **Backend**: `supabase/migrations/0002_command_views.sql` (`command_views`
+  table keyed by `command_id` + atomic `increment_command_view(cmd_id)` upsert
+  RPC + read-only RLS) and `functions/increment-command-view/index.ts` (Edge
+  Function; validates `command_id`, writes with the service-role key). The
+  function slug **must** be exactly `increment-command-view`.
+- **Client**: `js/popular-commands.js`. Reads all counts via REST with the anon
+  key; writes go only through the Edge Function. `commandId(item)` is
+  `` `${item.cls}:${item.name}` `` — the stable per-command key (the data has no
+  ids). `app.js` calls `recordOpen()` from `openModal()` and re-renders after
+  `loadCounts()` resolves.
+- **Counted once per session per command** (`sessionStorage` `cmd-opened:<id>`
+  guard) and **never for automated browsers** (`navigator.webdriver`), same as
+  the visitor counter.
+- **"Popular" = top ~10%** of commands that have at least one view, ranked by
+  count. Surfaced as a 🔥 badge on tiles and a "🔥 Popular" filter (next to
+  "⭐ Start Here") that sorts most-viewed-first.
+- **Reset the counts:** run `delete from public.command_views;` in the Supabase
+  SQL editor (cannot be done from the client/anon key).
+
 ## Testing
 
 Playwright, configured in `playwright.config.js`. Projects: `chromium`,
@@ -164,8 +188,5 @@ Non-trivial features follow brainstorm → spec → plan, saved under
 `docs/superpowers/specs/` and `docs/superpowers/plans/`. Check there for context.
 
 ### Known / planned improvements
-- **Popular commands (Supabase):** track command opens via the existing Supabase
-  backend and surface a "🔥 Popular" badge / "most viewed" sort. Designed-but-not-yet:
-  needs its own spec + plan.
 - Other ideas raised: favorites (localStorage), deep-link to a specific command,
   keyboard navigation, light/dark theme toggle, PWA/offline, multi-language snippets.

--- a/docs/superpowers/plans/2026-06-07-popular-commands.md
+++ b/docs/superpowers/plans/2026-06-07-popular-commands.md
@@ -1,0 +1,652 @@
+# Popular Commands Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Track how often each command's modal is opened (once per session per command) and surface the top ~10% as a 🔥 Popular badge on tiles plus a "🔥 Popular" filter that sorts most-viewed-first — reusing the existing Supabase visitor-counter infrastructure.
+
+**Architecture:** A new `command_views` table + atomic upsert RPC + a dedicated Edge Function (`increment-command-view`) handle server-side writes with the service-role key. A new ES module `js/popular-commands.js` records opens (anon → Edge Function) and reads all counts (anon → REST), computing the popular set. `js/app.js` wires the open-write into `openModal()`, adds the filter + tile badge, and re-renders once counts load.
+
+**Tech Stack:** Vanilla ES modules (no build step), Supabase (Postgres + Deno Edge Functions), Playwright tests with `page.route` network mocks.
+
+---
+
+## File Structure
+
+- **Create** `supabase/migrations/0002_command_views.sql` — table, upsert RPC, read-only RLS.
+- **Create** `supabase/functions/increment-command-view/index.ts` — Deno Edge Function that validates `command_id` and calls the RPC with the service-role key.
+- **Create** `js/popular-commands.js` — `commandId`, `recordOpen`, `loadCounts`, `getViewCount`, `isPopular`. The only module that talks to the command-views backend.
+- **Modify** `js/app.js` — import the module, expose it on `window`, call `recordOpen` in `openModal`, add the Popular filter + getItems sort branch, badge tiles, re-render after `loadCounts`.
+- **Modify** `style.css` — `.tile-popular` badge rule.
+- **Create** `tests/popular-commands.spec.js` — mocked Playwright coverage of write + read + UI.
+- **Modify** `AGENTS.md` — document the feature; remove it from "planned improvements".
+
+Note: SQL and the Deno Edge Function have no automated test harness in this repo (the visitor backend is the same). They're verified by inspection here and exercised end-to-end through the mocked client tests, exactly like `increment-visitor`.
+
+---
+
+### Task 1: Database migration
+
+**Files:**
+- Create: `supabase/migrations/0002_command_views.sql`
+
+- [ ] **Step 1: Write the migration**
+
+```sql
+-- Per-command open counter (one row per command, created on first open)
+create table if not exists public.command_views (
+  command_id text primary key,
+  view_count bigint not null default 0
+);
+
+-- Atomic upsert-increment: first open inserts the row, later opens add 1
+create or replace function public.increment_command_view(cmd_id text)
+returns void
+language sql
+as $$
+  insert into public.command_views (command_id, view_count)
+  values (cmd_id, 1)
+  on conflict (command_id)
+  do update set view_count = public.command_views.view_count + 1;
+$$;
+
+-- RLS: allow the public anon key to READ only (writes go through the
+-- Edge Function's service-role key, never the client)
+alter table public.command_views enable row level security;
+drop policy if exists "Allow public read" on public.command_views;
+create policy "Allow public read"
+  on public.command_views for select
+  using (true);
+```
+
+- [ ] **Step 2: Verify it parses (visual check against `0001_visits_counter.sql`)**
+
+Confirm: single-statement RPC body, `on conflict` qualifies the column with the table name (`public.command_views.view_count`) to avoid ambiguity, RLS enabled with a select-only policy. There is no local SQL runner; correctness is by inspection (matches the `0001` pattern).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add supabase/migrations/0002_command_views.sql
+git commit -m "feat: add command_views table + increment RPC"
+```
+
+---
+
+### Task 2: Edge Function
+
+**Files:**
+- Create: `supabase/functions/increment-command-view/index.ts`
+
+- [ ] **Step 1: Write the function**
+
+```ts
+// @ts-nocheck — Runs on Supabase's Deno runtime, not the editor's Node TS server.
+// URL imports and the `Deno` global are valid in Deno; this suppresses the
+// editor-only "Cannot find module / Cannot find name 'Deno'" false positives.
+import { createClient } from "https://esm.sh/@supabase/supabase-js@2";
+
+const corsHeaders = {
+  "Access-Control-Allow-Origin": "*",
+  "Access-Control-Allow-Headers":
+    "authorization, x-client-info, apikey, content-type",
+  "Access-Control-Allow-Methods": "POST, OPTIONS",
+};
+
+Deno.serve(async (req) => {
+  if (req.method === "OPTIONS") {
+    return new Response("ok", { headers: corsHeaders });
+  }
+  try {
+    const { command_id } = await req.json();
+    if (typeof command_id !== "string" || command_id.length === 0) {
+      return new Response(JSON.stringify({ error: "command_id required" }), {
+        status: 400,
+        headers: { ...corsHeaders, "Content-Type": "application/json" },
+      });
+    }
+
+    const supabase = createClient(
+      Deno.env.get("SUPABASE_URL")!,
+      Deno.env.get("SUPABASE_SERVICE_ROLE_KEY")!
+    );
+    const { error } = await supabase.rpc("increment_command_view", {
+      cmd_id: command_id,
+    });
+    if (error) throw error;
+
+    return new Response(JSON.stringify({ success: true }), {
+      headers: { ...corsHeaders, "Content-Type": "application/json" },
+    });
+  } catch (err) {
+    return new Response(JSON.stringify({ error: String(err) }), {
+      status: 500,
+      headers: { ...corsHeaders, "Content-Type": "application/json" },
+    });
+  }
+});
+```
+
+- [ ] **Step 2: Verify the slug and shape**
+
+Confirm the directory is exactly `supabase/functions/increment-command-view/` (the deployed slug must match the client URL in Task 3). Confirm it mirrors `increment-visitor/index.ts` except for body validation and the RPC name/arg.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add supabase/functions/increment-command-view/index.ts
+git commit -m "feat: add increment-command-view Edge Function"
+```
+
+---
+
+### Task 3: Client module + record opens (write path)
+
+**Files:**
+- Create: `js/popular-commands.js`
+- Modify: `js/app.js` (imports at top ~line 5; `openModal` ~line 128)
+- Test: `tests/popular-commands.spec.js`
+
+- [ ] **Step 1: Write the failing tests (helper + write-path cases)**
+
+Create `tests/popular-commands.spec.js`:
+
+```js
+import { test, expect } from '@playwright/test';
+
+const CORS = {
+  'access-control-allow-origin': '*',
+  'access-control-allow-methods': 'POST, GET, OPTIONS',
+  'access-control-allow-headers':
+    'authorization, content-type, apikey, x-client-info',
+};
+
+// Deterministic mocks so tests never hit real Supabase (flaky, rate-limited,
+// and a real write would inflate production counts). `state.rows` feeds the
+// command-views read; `state.opens` collects the command_ids written.
+async function mockBackends(page, { offline = false } = {}) {
+  const state = { rows: [], opens: [] };
+
+  await page.route('**/js/meta.json**', (route) =>
+    route.fulfill({
+      status: 200,
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ lastUpdated: '2025-12-25' }),
+    })
+  );
+
+  // Visitor counter (unrelated) — stubbed so it never reaches production.
+  await page.route('**/rest/v1/visits**', (route) =>
+    route.fulfill({
+      status: 200,
+      headers: { ...CORS, 'content-type': 'application/json' },
+      body: JSON.stringify([{ total_count: 0 }]),
+    })
+  );
+  await page.route('**/functions/v1/increment-visitor', (route) =>
+    route.fulfill({
+      status: 200,
+      headers: { ...CORS, 'content-type': 'application/json' },
+      body: '{"success":true}',
+    })
+  );
+
+  if (offline) {
+    await page.route('**/rest/v1/command_views**', (route) => route.abort());
+    await page.route('**/functions/v1/increment-command-view', (route) =>
+      route.abort()
+    );
+    return state;
+  }
+
+  // Read path: all command view counts (served from the mutable state.rows)
+  await page.route('**/rest/v1/command_views**', (route) =>
+    route.fulfill({
+      status: 200,
+      headers: { ...CORS, 'content-type': 'application/json' },
+      body: JSON.stringify(state.rows),
+    })
+  );
+
+  // Write path: record an open — capture command_id from real POSTs only
+  await page.route('**/functions/v1/increment-command-view', (route) => {
+    const req = route.request();
+    if (req.method() === 'POST') {
+      state.opens.push(JSON.parse(req.postData() || '{}').command_id);
+    }
+    route.fulfill({
+      status: 200,
+      headers: { ...CORS, 'content-type': 'application/json' },
+      body: '{"success":true}',
+    });
+  });
+
+  return state;
+}
+
+// The recorder skips automated browsers (navigator.webdriver === true under
+// Playwright). Tests that assert an open is recorded must pose as a real
+// visitor first (same helper idea as meta-bar.spec.js).
+async function poseAsRealVisitor(page) {
+  await page.addInitScript(() =>
+    Object.defineProperty(navigator, 'webdriver', { get: () => false })
+  );
+}
+
+test.describe('Popular commands — record opens', () => {
+  test('does NOT record opens in automated browsers (CI / bots)', async ({
+    page,
+  }) => {
+    const state = await mockBackends(page);
+    await page.goto('/'); // navigator.webdriver is true under Playwright
+    await page.locator('.tile').first().click();
+    await expect(page.locator('#modal')).toBeVisible();
+    await page.waitForTimeout(300);
+
+    expect(state.opens.length).toBe(0);
+  });
+
+  test('records one open with the command_id (real visitor)', async ({
+    page,
+  }) => {
+    await poseAsRealVisitor(page);
+    const state = await mockBackends(page);
+    await page.goto('/');
+
+    const tile = page.locator('.tile').first();
+    const name = await tile.locator('.tile-name').innerText();
+    await tile.click();
+    await expect(page.locator('#modal')).toBeVisible();
+    await page.waitForTimeout(300);
+
+    expect(state.opens.length).toBe(1);
+    // command_id is `${cls}:${name}` — it must contain the command name
+    expect(state.opens[0]).toContain(name);
+  });
+
+  test('records each command at most once per session', async ({ page }) => {
+    await poseAsRealVisitor(page);
+    const state = await mockBackends(page);
+    await page.goto('/');
+
+    const tile = page.locator('.tile').first();
+    await tile.click();
+    await page.locator('#btn-close').click();
+    await tile.click(); // second open of the same command
+    await page.waitForTimeout(300);
+
+    expect(state.opens.length).toBe(1);
+  });
+});
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `npx playwright test tests/popular-commands.spec.js --project=chromium`
+Expected: FAIL — opens are never recorded (no `recordOpen` wired yet), so the "records one open" and "once per session" tests fail (`state.opens.length` is 0). The bot test may pass vacuously; that's fine.
+
+- [ ] **Step 3: Create the client module**
+
+Create `js/popular-commands.js`:
+
+```js
+// =============================================================
+// popular-commands.js — per-command "open" counts via Supabase.
+// Mirrors the visitor counter: WRITES go server-side through an
+// Edge Function (service-role key); READS use the publishable anon
+// key directly. Exposes a "popular" set (top ~10% by opens) for the
+// UI to badge + sort.
+// =============================================================
+
+const SUPABASE_URL = 'https://tilbhgcncnwibnfgebkg.supabase.co';
+const SUPABASE_KEY = 'sb_publishable_yCaOt8Z9sl-JEQC5wZ6_sQ_jZi610z1';
+const FUNCTION_URL = `${SUPABASE_URL}/functions/v1/increment-command-view`;
+const REST_URL = `${SUPABASE_URL}/rest/v1/command_views?select=command_id,view_count`;
+const CACHE_KEY = 'command-views-cache';
+const SESSION_PREFIX = 'cmd-opened:';
+
+// id -> view_count for the current load; `popular` is a Set of ids.
+let counts = new Map();
+let popular = new Set();
+
+// Stable identity for a command (the data has no ids): category class + name.
+export function commandId(item) {
+  return `${item.cls}:${item.name}`;
+}
+
+export function getViewCount(id) {
+  return counts.get(id) || 0;
+}
+
+export function isPopular(id) {
+  return popular.has(id);
+}
+
+// Build the counts map and the popular set (top ~10% of commands that have
+// at least one view, ranked by view_count descending).
+function applyRows(rows) {
+  counts = new Map();
+  rows.forEach((r) => counts.set(r.command_id, Number(r.view_count) || 0));
+
+  const viewed = [...counts.entries()]
+    .filter(([, n]) => n > 0)
+    .sort((a, b) => b[1] - a[1]);
+  const topN = Math.ceil(viewed.length * 0.1);
+  popular = new Set(viewed.slice(0, topN).map(([id]) => id));
+}
+
+// Fetch all counts once. Resolves so the caller can re-render. Falls back to
+// the cached rows (then to empty) so the page never breaks on an outage.
+export function loadCounts() {
+  return fetch(`${REST_URL}&apikey=${SUPABASE_KEY}`, {
+    signal: AbortSignal.timeout(5000),
+  })
+    .then((res) => res.json())
+    .then((rows) => {
+      if (Array.isArray(rows)) {
+        applyRows(rows);
+        localStorage.setItem(CACHE_KEY, JSON.stringify(rows));
+      }
+    })
+    .catch((err) => {
+      console.debug('Command views unavailable:', err);
+      const cached = localStorage.getItem(CACHE_KEY);
+      if (cached) {
+        try {
+          applyRows(JSON.parse(cached));
+        } catch {
+          /* ignore a corrupt cache */
+        }
+      }
+    });
+}
+
+// Record an open: once per session per command, never for automated browsers.
+export function recordOpen(item) {
+  try {
+    // Skip CI/Playwright/Selenium/most bots so they don't inflate counts.
+    if (navigator.webdriver) return;
+
+    const id = commandId(item);
+    const key = SESSION_PREFIX + id;
+    if (sessionStorage.getItem(key)) return; // already counted this session
+    sessionStorage.setItem(key, '1');
+
+    fetch(FUNCTION_URL, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${SUPABASE_KEY}`,
+      },
+      body: JSON.stringify({ command_id: id }),
+    }).catch((err) => {
+      console.debug('Command view counter unavailable:', err);
+    });
+  } catch (err) {
+    console.debug('Command view counter error:', err);
+  }
+}
+```
+
+- [ ] **Step 4: Wire the write into app.js**
+
+In `js/app.js`, add the import alongside the existing ones (after the `highlight` import near line 6):
+
+```js
+import * as popularCmds from './popular-commands.js';
+```
+
+Below the existing `window.*` test exposures (after line 12), add:
+
+```js
+// Expose for tests via page.evaluate() (same rationale as window.categories)
+window.popularCommands = popularCmds;
+```
+
+At the end of `openModal(item)` (after the copy-button reset, ~line 153), add:
+
+```js
+  // Record this open for the popularity counter (no-op for bots / repeat opens)
+  popularCmds.recordOpen(item);
+```
+
+- [ ] **Step 5: Run the tests to verify they pass**
+
+Run: `npx playwright test tests/popular-commands.spec.js --project=chromium`
+Expected: PASS — all three "record opens" tests green.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add js/popular-commands.js js/app.js tests/popular-commands.spec.js
+git commit -m "feat: record command opens via Supabase (once per session)"
+```
+
+---
+
+### Task 4: Popular badge + filter (read path / UI)
+
+**Files:**
+- Modify: `js/app.js` (`getItems` ~line 28, `makeTile` ~line 114, `buildFilters` ~line 218, init/end of file ~line 308)
+- Modify: `style.css` (after the `.tile-level` rule, ~line 110)
+- Test: `tests/popular-commands.spec.js` (append a second describe block)
+
+- [ ] **Step 1: Write the failing tests (badge + filter + graceful failure)**
+
+Append to `tests/popular-commands.spec.js`:
+
+```js
+test.describe('Popular commands — badge + filter', () => {
+  // Returns the flat list of { id, name } for every command, in render order.
+  async function allCommands(page) {
+    return page.evaluate(() =>
+      window.categories.flatMap((c) =>
+        c.items.map((i) => ({ id: `${c.cls}:${i.name}`, name: i.name }))
+      )
+    );
+  }
+
+  test('badges only the popular commands (top ~10% with views)', async ({
+    page,
+  }) => {
+    const state = await mockBackends(page);
+    await page.goto('/');
+    const cmds = await allCommands(page);
+
+    // Give 20 commands views → top 10% = ceil(2.0) = 2 popular tiles.
+    state.rows = cmds
+      .slice(0, 20)
+      .map((c, i) => ({ command_id: c.id, view_count: 20 - i }));
+    await page.reload();
+
+    await expect(page.locator('.tile-popular')).toHaveCount(2);
+  });
+
+  test('🔥 Popular filter shows popular commands, most-viewed first', async ({
+    page,
+  }) => {
+    const state = await mockBackends(page);
+    await page.goto('/');
+    const cmds = await allCommands(page);
+
+    state.rows = cmds
+      .slice(0, 20)
+      .map((c, i) => ({ command_id: c.id, view_count: 20 - i }));
+    await page.reload();
+    await page.locator('.tile-popular').first().waitFor();
+
+    await page.getByRole('button', { name: '🔥 Popular' }).click();
+
+    const names = await page.locator('.tile .tile-name').allInnerTexts();
+    expect(names.length).toBe(2); // ceil(20 * 0.1)
+    expect(names[0]).toBe(cmds[0].name); // highest view_count first
+  });
+
+  test('no badges and page still works when counts fail to load', async ({
+    page,
+  }) => {
+    await mockBackends(page, { offline: true });
+    await page.goto('/');
+    await page.waitForTimeout(300);
+
+    expect(await page.locator('.tile-popular').count()).toBe(0);
+    expect(await page.locator('.tile').count()).toBeGreaterThan(10);
+  });
+});
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `npx playwright test tests/popular-commands.spec.js --project=chromium`
+Expected: FAIL — `.tile-popular` never renders (count 0, not 2) and the `🔥 Popular` filter button doesn't exist, so `getByRole(...).click()` times out.
+
+- [ ] **Step 3: Add the Popular filter button (app.js `buildFilters`)**
+
+In `js/app.js`, change the `defs` array in `buildFilters()` (lines 220-224) to insert the Popular entry right after "Start Here":
+
+```js
+  const defs = [
+    { label: 'All',          filter: 'all',      color: null },
+    { label: '⭐ Start Here', filter: 'beginner', color: null },
+    { label: '🔥 Popular',   filter: 'popular',  color: null },
+    ...categories.map(c => ({ label: c.cat, filter: c.cat, color: c.color }))
+  ];
+```
+
+- [ ] **Step 4: Add the popular filter/sort branch (app.js `getItems`)**
+
+In `js/app.js`, replace the filter block in `getItems()` (lines 31-35) with a version that adds a `popular` branch *before* the category branch:
+
+```js
+  if (activeFilter === 'beginner') {
+    items = items.filter(i => i.level === 'beginner');
+  } else if (activeFilter === 'popular') {
+    items = items
+      .filter(i => popularCmds.isPopular(popularCmds.commandId(i)))
+      .sort(
+        (a, b) =>
+          popularCmds.getViewCount(popularCmds.commandId(b)) -
+          popularCmds.getViewCount(popularCmds.commandId(a))
+      );
+  } else if (activeFilter !== 'all') {
+    items = items.filter(i => i.cat === activeFilter);
+  }
+```
+
+- [ ] **Step 5: Badge popular tiles (app.js `makeTile`)**
+
+In `js/app.js`, update `makeTile()` (lines 114-125) to add the badge:
+
+```js
+function makeTile(item, n) {
+  const div = document.createElement('div');
+  div.className = `tile ${item.cls}`;
+  const popularBadge = popularCmds.isPopular(popularCmds.commandId(item))
+    ? '<span class="tile-popular" title="Popular">🔥</span>'
+    : '';
+  div.innerHTML = `
+    <span class="tile-level">${levelDots(item.level)}</span>
+    ${popularBadge}
+    <div class="tile-inner">
+      <span class="tile-num">#${n}</span>
+      <span class="tile-name">${item.name}</span>
+    </div>`;
+  div.addEventListener('click', () => openModal(item));
+  return div;
+}
+```
+
+- [ ] **Step 6: Load counts and re-render after first paint (app.js end of file)**
+
+In `js/app.js`, at the very end of the file (after the `applyHashState();` call on line 308), add:
+
+```js
+// Popularity data arrives after first paint; re-render once it lands so the
+// 🔥 badges appear and the "🔥 Popular" filter has content. Fails gracefully
+// (no badges) if the backend is unreachable.
+popularCmds.loadCounts().then(render);
+```
+
+- [ ] **Step 7: Style the badge (style.css)**
+
+In `style.css`, add after the `.tile-level` rule (after line 110), mirroring its absolute positioning but on the left so it never overlaps the difficulty dots:
+
+```css
+.tile-popular {
+  position: absolute; top: 6px; left: 8px;
+  font-size: 11px; line-height: 1;
+}
+```
+
+- [ ] **Step 8: Run the tests to verify they pass**
+
+Run: `npx playwright test tests/popular-commands.spec.js --project=chromium`
+Expected: PASS — all six tests green (three from Task 3, three here).
+
+- [ ] **Step 9: Lint, format, full suite**
+
+Run: `npm run lint && npm run format:check && npm test`
+Expected: lint clean, format clean, all Playwright projects pass. (No new browser globals were introduced — `navigator`, `fetch`, `sessionStorage`, `localStorage`, `AbortSignal` are already whitelisted in `eslint.config.js`; the test file only uses already-whitelisted globals via `window`/`navigator`.)
+
+- [ ] **Step 10: Commit**
+
+```bash
+git add js/app.js style.css tests/popular-commands.spec.js
+git commit -m "feat: 🔥 Popular badge + filter sorted by command opens"
+```
+
+---
+
+### Task 5: Documentation
+
+**Files:**
+- Modify: `AGENTS.md` (the "Visitor counter (Supabase)" section ~mid-file, and "Known / planned improvements" near the end)
+
+- [ ] **Step 1: Add a "Popular commands (Supabase)" subsection**
+
+In `AGENTS.md`, immediately after the "Visitor counter (Supabase)" section, add:
+
+```markdown
+## Popular commands (Supabase)
+
+Reuses the visitor-counter infra to count command **opens** and surface the most
+popular ones.
+
+- **Backend**: `supabase/migrations/0002_command_views.sql` (`command_views`
+  table keyed by `command_id` + atomic `increment_command_view(cmd_id)` upsert
+  RPC + read-only RLS) and `functions/increment-command-view/index.ts` (Edge
+  Function; validates `command_id`, writes with the service-role key). The
+  function slug **must** be exactly `increment-command-view`.
+- **Client**: `js/popular-commands.js`. Reads all counts via REST with the anon
+  key; writes go only through the Edge Function. `commandId(item)` is
+  `` `${item.cls}:${item.name}` `` — the stable per-command key (the data has no
+  ids). `app.js` calls `recordOpen()` from `openModal()` and re-renders after
+  `loadCounts()` resolves.
+- **Counted once per session per command** (`sessionStorage` `cmd-opened:<id>`
+  guard) and **never for automated browsers** (`navigator.webdriver`), same as
+  the visitor counter.
+- **"Popular" = top ~10%** of commands that have at least one view, ranked by
+  count. Surfaced as a 🔥 badge on tiles and a "🔥 Popular" filter (next to
+  "⭐ Start Here") that sorts most-viewed-first.
+- **Reset the counts:** run `delete from public.command_views;` in the Supabase
+  SQL editor (cannot be done from the client/anon key).
+```
+
+- [ ] **Step 2: Remove the item from "Known / planned improvements"**
+
+In `AGENTS.md`, delete the "Popular commands (Supabase)" bullet under "Known / planned improvements" (it's now shipped and documented above).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add AGENTS.md
+git commit -m "docs: document Popular commands feature"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage:** Backend table/RPC/RLS → Task 1. Edge Function with validation → Task 2. `commandId`/`recordOpen`/`loadCounts`/`getViewCount`/`isPopular`, once-per-session + bot guards, graceful fallback → Task 3 + Task 4. Top-10% popular set → `applyRows` (Task 3). 🔥 badge + "🔥 Popular" filter sorted most-viewed-first → Task 4. Tests for all six spec test cases → Tasks 3-4. Docs + reset instructions → Task 5. No live polling, no modal indicator (Out of scope) — correctly omitted.
+
+**Placeholder scan:** No TBD/TODO; every code step shows complete code; every run step states the exact command and expected result.
+
+**Type/name consistency:** `commandId`, `recordOpen`, `loadCounts`, `getViewCount`, `isPopular` are defined in `popular-commands.js` (Task 3) and called identically in `app.js` (Tasks 3-4). The import alias `popularCmds` is used consistently. The Edge Function RPC arg `cmd_id` matches the SQL function signature (Task 1) and the `{ command_id }` body matches what the client sends and what the function reads. The `.tile-popular` class, `cmd-opened:` session prefix, and `command-views-cache` key are each used consistently across module, CSS, and tests.

--- a/docs/superpowers/specs/2026-06-07-popular-commands-design.md
+++ b/docs/superpowers/specs/2026-06-07-popular-commands-design.md
@@ -1,0 +1,186 @@
+# Popular Commands — Design
+
+**Date:** 2026-06-07
+**Status:** Approved
+
+## Goal
+
+Track which commands people open and surface popularity in the UI:
+
+- A **🔥 Popular** badge on the most-opened command tiles.
+- A **🔥 Popular** filter (beside **⭐ Start Here**) that shows only popular
+  commands, most-viewed first.
+
+This reuses the existing Supabase visitor-counter infrastructure, making it do
+double duty: server-side counting via an Edge Function, read-only anon access
+via REST.
+
+## Constraints
+
+- The site is vanilla ES modules with **no build step**, served from GitHub
+  Pages, and should keep working **offline-friendly** — no CDN, no third-party
+  runtime libraries.
+- **Security invariant (must hold):** writes happen only server-side inside an
+  Edge Function using the **service-role key**. Client/anon code may **read
+  only**. Never expose a write path to the anon key.
+- **Automated browsers must not inflate counts** — skip when
+  `navigator.webdriver` is true (CI/Playwright/Selenium/most bots), matching
+  the visitor counter.
+- All Supabase traffic must **fail gracefully**: a network/Supabase outage
+  leaves the page fully usable with no badges and no console errors.
+
+## Decisions (settled during brainstorming)
+
+- **Counting granularity:** once per session per command. A session that opens
+  a command's modal increments that command exactly once, no matter how many
+  times it's reopened (`sessionStorage` guard per command).
+- **What "popular" means:** the top ~10% of commands *that have at least one
+  view*, ranked by view count descending. Concretely
+  `Math.ceil(0.10 × commandsWithViews)`. When nothing has been opened yet, the
+  popular set is empty (no badges, no items in the Popular filter).
+- **Sort UI:** a `🔥 Popular` filter button next to `⭐ Start Here` that filters
+  to the popular set and orders it most-viewed-first (not a third view toggle).
+
+## Command identity
+
+Commands have no stable IDs in the data, so derive one:
+
+```
+commandId(item) = `${item.cls}:${item.name}`   // e.g. "action:click()"
+```
+
+Exported from `js/popular-commands.js` for reuse in `app.js` and tests. Stable
+as long as a command's category (`cls`) and `name` don't change; renaming a
+command resets only that command's count — acceptable.
+
+## Architecture
+
+### Backend (`supabase/`)
+
+New migration `migrations/0002_command_views.sql`:
+
+```sql
+create table if not exists public.command_views (
+  command_id text primary key,
+  view_count bigint not null default 0
+);
+
+-- Atomic upsert-increment: first open inserts, later opens add 1
+create or replace function public.increment_command_view(cmd_id text)
+returns void language sql as $$
+  insert into public.command_views (command_id, view_count)
+  values (cmd_id, 1)
+  on conflict (command_id)
+  do update set view_count = public.command_views.view_count + 1;
+$$;
+
+-- RLS: anon may READ only
+alter table public.command_views enable row level security;
+drop policy if exists "Allow public read" on public.command_views;
+create policy "Allow public read"
+  on public.command_views for select using (true);
+```
+
+New Edge Function `functions/increment-command-view/index.ts` — a near-copy of
+`increment-visitor`:
+
+- Same CORS headers; handle `OPTIONS` preflight.
+- Read `{ command_id }` from the JSON body. **Validate** it is a non-empty
+  string; if not, return `400` with an error body.
+- Create the service-role client and call
+  `supabase.rpc("increment_command_view", { cmd_id: command_id })`.
+- Return `{ success: true }` on success; `500` with `{ error }` on failure.
+- The Deno-runtime conventions (`@ts-nocheck`, URL imports, `Deno` global) are
+  intentional, exactly like the existing function.
+
+The function slug **must** be exactly `increment-command-view`.
+
+### Client module (`js/popular-commands.js`, an ES module)
+
+Mirrors the visitor split (write vs read) in one command-scoped module. Uses
+the same Supabase project URL and publishable anon key already present in the
+visitor scripts. Exports:
+
+- `commandId(item)` — the `cls:name` key (above).
+- `recordOpen(item)` — called from `openModal()`. Returns early if
+  `navigator.webdriver`, or if `sessionStorage["cmd-opened:"+id]` is set
+  (once-per-session-per-command); otherwise sets that guard and fires a
+  fire-and-forget `POST` to `…/functions/v1/increment-command-view` with body
+  `{ command_id: id }` and the publishable-key `Authorization` header. All
+  failures `console.debug` only.
+- `loadCounts()` — `GET …/rest/v1/command_views?select=command_id,view_count`
+  with the anon `apikey` and a 5s `AbortSignal.timeout`. On success: build an
+  `id → count` map; compute the popular set (`view_count > 0`, ranked desc,
+  take `Math.ceil(0.10 × commandsWithViews)`); cache the raw rows to
+  `localStorage`. On failure: fall back to the cached rows if present, else an
+  empty map. Resolves a promise so `app.js` can re-render.
+- `getViewCount(id)` / `isPopular(id)` — accessors used during render.
+
+### UI (`js/app.js`, `index.html`, `style.css`)
+
+- **Popular filter:** in `buildFilters()`, insert
+  `{ label: '🔥 Popular', filter: 'popular' }` immediately after
+  `⭐ Start Here`. In `getItems()`, when `activeFilter === 'popular'`: keep only
+  items where `isPopular(commandId(item))`, then sort by `getViewCount`
+  descending. Search composes on top as today.
+- **Tile badge:** `makeTile()` adds a `🔥` element when the item is popular,
+  positioned opposite the existing `tile-level` dots so they don't overlap.
+  New `.tile-popular` rule in `style.css`.
+- **Async refresh:** counts arrive after first paint, so `app.js` calls
+  `loadCounts().then(render)`. First render shows no badges; once data lands it
+  re-renders with badges — the same "fill in when ready" model as the meta bar.
+- **Wire the write:** `openModal()` calls `recordOpen(item)`.
+- **Test hook:** expose `window.popularCommands` (the module) for
+  `page.evaluate()`, consistent with `window.categories`.
+
+## Data flow
+
+1. Page loads → `app.js` renders tiles (no badges yet) and calls
+   `loadCounts()`.
+2. `loadCounts()` resolves → popular set computed → `render()` re-runs → badges
+   appear; `🔥 Popular` filter now has content.
+3. User opens a command modal → `recordOpen(item)` POSTs to the Edge Function
+   (once per session per command, skipped for bots) → DB increments.
+4. Updated counts are reflected on the next page load (no live polling — see
+   Out of scope).
+
+## Error handling
+
+- Edge Function unreachable / non-2xx on write → swallowed (`console.debug`);
+  user sees no error, modal works normally.
+- `loadCounts()` fetch fails → cached rows used if available, else empty set →
+  no badges, no Popular items, no thrown errors.
+- Invalid/empty `command_id` → Edge Function returns `400`; client ignores it.
+
+## Testing (`tests/popular-commands.spec.js`)
+
+All Supabase traffic mocked with `page.route` — deterministic and no real
+writes (same pattern as `tests/meta-bar.spec.js`):
+
+- Tiles get the 🔥 badge only for the mocked popular set; non-popular tiles
+  don't.
+- The `🔥 Popular` filter shows only popular items, ordered most-viewed-first.
+- Opening a modal fires exactly one `POST` with the correct `command_id`
+  (faking `navigator.webdriver = false` via the `poseAsRealVisitor` pattern).
+- Once-per-session guard: reopening the same command fires no second `POST`.
+- `navigator.webdriver = true` → no `POST` at all.
+- Mocked `500`/failure on `loadCounts()` → no badges, page still works, no
+  console errors.
+
+Plus `npm run lint` and `npm run format:check` clean; whitelist any new
+browser globals in `eslint.config.js` rather than disabling rules.
+
+## Documentation
+
+Add a **Popular commands (Supabase)** subsection to AGENTS.md (backend files,
+the read/write split, the once-per-session-per-command guard, the bot
+exclusion, and how to reset counts: `delete from public.command_views;` in the
+SQL editor). Move the item out of "Known / planned improvements".
+
+## Out of scope
+
+- Live polling of counts (the visitor display polls; popularity refreshes on
+  next load — simpler, and popularity changes slowly). Revisit only if needed.
+- A popularity indicator inside the modal (badge is on tiles only).
+- Trending / time-windowed popularity (e.g. "this week"); counts are all-time.
+- Per-user history or de-duplication beyond the per-session guard.

--- a/js/app.js
+++ b/js/app.js
@@ -33,6 +33,14 @@ function getItems() {
 
   if (activeFilter === 'beginner') {
     items = items.filter(i => i.level === 'beginner');
+  } else if (activeFilter === 'popular') {
+    items = items
+      .filter(i => popularCmds.isPopular(popularCmds.commandId(i)))
+      .sort(
+        (a, b) =>
+          popularCmds.getViewCount(popularCmds.commandId(b)) -
+          popularCmds.getViewCount(popularCmds.commandId(a))
+      );
   } else if (activeFilter !== 'all') {
     items = items.filter(i => i.cat === activeFilter);
   }
@@ -117,8 +125,12 @@ function levelDots(level) {
 function makeTile(item, n) {
   const div = document.createElement('div');
   div.className = `tile ${item.cls}`;
+  const popularBadge = popularCmds.isPopular(popularCmds.commandId(item))
+    ? '<span class="tile-popular" title="Popular">🔥</span>'
+    : '';
   div.innerHTML = `
     <span class="tile-level">${levelDots(item.level)}</span>
+    ${popularBadge}
     <div class="tile-inner">
       <span class="tile-num">#${n}</span>
       <span class="tile-name">${item.name}</span>
@@ -226,6 +238,7 @@ function buildFilters() {
   const defs = [
     { label: 'All',          filter: 'all',      color: null },
     { label: '⭐ Start Here', filter: 'beginner', color: null },
+    { label: '🔥 Popular',   filter: 'popular',  color: null },
     ...categories.map(c => ({ label: c.cat, filter: c.cat, color: c.color }))
   ];
   defs.forEach(({ label, filter, color }) => {
@@ -312,3 +325,8 @@ buildFilters();
 }());
 
 applyHashState();
+
+// Popularity data arrives after first paint; re-render once it lands so the
+// 🔥 badges appear and the "🔥 Popular" filter has content. Fails gracefully
+// (no badges) if the backend is unreachable.
+popularCmds.loadCounts().then(render).catch(() => {});

--- a/js/app.js
+++ b/js/app.js
@@ -4,12 +4,15 @@
 
 import { categories } from './data/index.js';
 import { highlight, highlightShell } from './highlight.js';
+import * as popularCmds from './popular-commands.js';
 
 // Expose as a global so data-integrity tests can access it via page.evaluate()
 window.categories = categories;
 // Expose for tests via page.evaluate() (same rationale as window.categories)
 window.highlight = highlight;
 window.highlightShell = highlightShell;
+// Expose for tests via page.evaluate() (same rationale as window.categories)
+window.popularCommands = popularCmds;
 
 /* ── STATE ────────────────────────────────────────────────────── */
 let activeFilter = 'all';
@@ -151,6 +154,9 @@ function openModal(item) {
   const copyBtn = document.getElementById('btn-copy');
   copyBtn.textContent = 'Copy';
   copyBtn.className   = 'btn-copy';
+
+  // Record this open for the popularity counter (no-op for bots / repeat opens)
+  popularCmds.recordOpen(item);
 }
 
 function closeModal() {

--- a/js/popular-commands.js
+++ b/js/popular-commands.js
@@ -1,0 +1,95 @@
+// =============================================================
+// popular-commands.js — per-command "open" counts via Supabase.
+// Mirrors the visitor counter: WRITES go server-side through an
+// Edge Function (service-role key); READS use the publishable anon
+// key directly. Exposes a "popular" set (top ~10% by opens) for the
+// UI to badge + sort.
+// =============================================================
+
+const SUPABASE_URL = 'https://tilbhgcncnwibnfgebkg.supabase.co';
+const SUPABASE_KEY = 'sb_publishable_yCaOt8Z9sl-JEQC5wZ6_sQ_jZi610z1';
+const FUNCTION_URL = `${SUPABASE_URL}/functions/v1/increment-command-view`;
+const REST_URL = `${SUPABASE_URL}/rest/v1/command_views?select=command_id,view_count`;
+const CACHE_KEY = 'command-views-cache';
+const SESSION_PREFIX = 'cmd-opened:';
+
+// id -> view_count for the current load; `popular` is a Set of ids.
+let counts = new Map();
+let popular = new Set();
+
+// Stable identity for a command (the data has no ids): category class + name.
+export function commandId(item) {
+  return `${item.cls}:${item.name}`;
+}
+
+export function getViewCount(id) {
+  return counts.get(id) || 0;
+}
+
+export function isPopular(id) {
+  return popular.has(id);
+}
+
+// Build the counts map and the popular set (top ~10% of commands that have
+// at least one view, ranked by view_count descending).
+function applyRows(rows) {
+  counts = new Map();
+  rows.forEach((r) => counts.set(r.command_id, Number(r.view_count) || 0));
+
+  const viewed = [...counts.entries()].filter(([, n]) => n > 0).sort((a, b) => b[1] - a[1]);
+  const topN = Math.ceil(viewed.length * 0.1);
+  popular = new Set(viewed.slice(0, topN).map(([id]) => id));
+}
+
+// Fetch all counts once. Resolves so the caller can re-render. Falls back to
+// the cached rows (then to empty) so the page never breaks on an outage.
+export function loadCounts() {
+  return fetch(`${REST_URL}&apikey=${SUPABASE_KEY}`, {
+    signal: AbortSignal.timeout(5000),
+  })
+    .then((res) => res.json())
+    .then((rows) => {
+      if (!Array.isArray(rows)) {
+        throw new Error('Unexpected command_views response');
+      }
+      applyRows(rows);
+      localStorage.setItem(CACHE_KEY, JSON.stringify(rows));
+    })
+    .catch((err) => {
+      console.debug('Command views unavailable:', err);
+      const cached = localStorage.getItem(CACHE_KEY);
+      if (cached) {
+        try {
+          applyRows(JSON.parse(cached));
+        } catch {
+          /* ignore a corrupt cache */
+        }
+      }
+    });
+}
+
+// Record an open: once per session per command, never for automated browsers.
+export function recordOpen(item) {
+  try {
+    // Skip CI/Playwright/Selenium/most bots so they don't inflate counts.
+    if (navigator.webdriver) return;
+
+    const id = commandId(item);
+    const key = SESSION_PREFIX + id;
+    if (sessionStorage.getItem(key)) return; // already counted this session
+    sessionStorage.setItem(key, '1');
+
+    fetch(FUNCTION_URL, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${SUPABASE_KEY}`,
+      },
+      body: JSON.stringify({ command_id: id }),
+    }).catch((err) => {
+      console.debug('Command view counter unavailable:', err);
+    });
+  } catch (err) {
+    console.debug('Command view counter error:', err);
+  }
+}

--- a/style.css
+++ b/style.css
@@ -108,6 +108,10 @@ input[type=text]:focus { outline: none; border-color: #64748b; }
   position: absolute; top: 7px; right: 9px;
   font-size: 8px; letter-spacing: 1px; line-height: 1;
 }
+.tile-popular {
+  position: absolute; top: 6px; left: 8px;
+  font-size: 11px; line-height: 1;
+}
 .tile-inner { display: flex; flex-direction: column; align-items: center; gap: 3px; width: 100%; }
 .tile-num   { font-size: 11px; opacity: 0.65; }
 .tile-name  { font-size: 15px; overflow-wrap: anywhere; width: 100%; text-align: center; }

--- a/supabase/functions/increment-command-view/index.ts
+++ b/supabase/functions/increment-command-view/index.ts
@@ -1,0 +1,44 @@
+// @ts-nocheck — Runs on Supabase's Deno runtime, not the editor's Node TS server.
+// URL imports and the `Deno` global are valid in Deno; this suppresses the
+// editor-only "Cannot find module / Cannot find name 'Deno'" false positives.
+import { createClient } from "https://esm.sh/@supabase/supabase-js@2";
+
+const corsHeaders = {
+  "Access-Control-Allow-Origin": "*",
+  "Access-Control-Allow-Headers":
+    "authorization, x-client-info, apikey, content-type",
+  "Access-Control-Allow-Methods": "POST, OPTIONS",
+};
+
+Deno.serve(async (req) => {
+  if (req.method === "OPTIONS") {
+    return new Response("ok", { headers: corsHeaders });
+  }
+  try {
+    const { command_id } = await req.json();
+    if (typeof command_id !== "string" || command_id.length === 0) {
+      return new Response(JSON.stringify({ error: "command_id required" }), {
+        status: 400,
+        headers: { ...corsHeaders, "Content-Type": "application/json" },
+      });
+    }
+
+    const supabase = createClient(
+      Deno.env.get("SUPABASE_URL")!,
+      Deno.env.get("SUPABASE_SERVICE_ROLE_KEY")!
+    );
+    const { error } = await supabase.rpc("increment_command_view", {
+      cmd_id: command_id,
+    });
+    if (error) throw error;
+
+    return new Response(JSON.stringify({ success: true }), {
+      headers: { ...corsHeaders, "Content-Type": "application/json" },
+    });
+  } catch (err) {
+    return new Response(JSON.stringify({ error: String(err) }), {
+      status: 500,
+      headers: { ...corsHeaders, "Content-Type": "application/json" },
+    });
+  }
+});

--- a/supabase/migrations/0002_command_views.sql
+++ b/supabase/migrations/0002_command_views.sql
@@ -1,0 +1,24 @@
+-- Per-command open counter (one row per command, created on first open)
+create table if not exists public.command_views (
+  command_id text primary key,
+  view_count bigint not null default 0
+);
+
+-- Atomic upsert-increment: first open inserts the row, later opens add 1
+create or replace function public.increment_command_view(cmd_id text)
+returns void
+language sql
+as $$
+  insert into public.command_views (command_id, view_count)
+  values (cmd_id, 1)
+  on conflict (command_id)
+  do update set view_count = public.command_views.view_count + 1;
+$$;
+
+-- RLS: allow the public anon key to READ only (writes go through the
+-- Edge Function's service-role key, never the client)
+alter table public.command_views enable row level security;
+drop policy if exists "Allow public read" on public.command_views;
+create policy "Allow public read"
+  on public.command_views for select
+  using (true);

--- a/tests/popular-commands.spec.js
+++ b/tests/popular-commands.spec.js
@@ -1,0 +1,120 @@
+import { test, expect } from '@playwright/test';
+
+const CORS = {
+  'access-control-allow-origin': '*',
+  'access-control-allow-methods': 'POST, GET, OPTIONS',
+  'access-control-allow-headers': 'authorization, content-type, apikey, x-client-info',
+};
+
+// Deterministic mocks so tests never hit real Supabase (flaky, rate-limited,
+// and a real write would inflate production counts). `state.rows` feeds the
+// command-views read; `state.opens` collects the command_ids written.
+async function mockBackends(page, { offline = false } = {}) {
+  const state = { rows: [], opens: [] };
+
+  await page.route('**/js/meta.json**', (route) =>
+    route.fulfill({
+      status: 200,
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ lastUpdated: '2025-12-25' }),
+    })
+  );
+
+  // Visitor counter (unrelated) — stubbed so it never reaches production.
+  await page.route('**/rest/v1/visits**', (route) =>
+    route.fulfill({
+      status: 200,
+      headers: { ...CORS, 'content-type': 'application/json' },
+      body: JSON.stringify([{ total_count: 0 }]),
+    })
+  );
+  await page.route('**/functions/v1/increment-visitor', (route) =>
+    route.fulfill({
+      status: 200,
+      headers: { ...CORS, 'content-type': 'application/json' },
+      body: '{"success":true}',
+    })
+  );
+
+  if (offline) {
+    await page.route('**/rest/v1/command_views**', (route) => route.abort());
+    await page.route('**/functions/v1/increment-command-view', (route) => route.abort());
+    return state;
+  }
+
+  // Read path: all command view counts (served from the mutable state.rows)
+  await page.route('**/rest/v1/command_views**', (route) =>
+    route.fulfill({
+      status: 200,
+      headers: { ...CORS, 'content-type': 'application/json' },
+      body: JSON.stringify(state.rows),
+    })
+  );
+
+  // Write path: record an open — capture command_id from real POSTs only
+  await page.route('**/functions/v1/increment-command-view', (route) => {
+    const req = route.request();
+    if (req.method() === 'POST') {
+      state.opens.push(JSON.parse(req.postData() || '{}').command_id);
+    }
+    route.fulfill({
+      status: 200,
+      headers: { ...CORS, 'content-type': 'application/json' },
+      body: '{"success":true}',
+    });
+  });
+
+  return state;
+}
+
+// The recorder skips automated browsers (navigator.webdriver === true under
+// Playwright). Tests that assert an open is recorded must pose as a real
+// visitor first (same helper idea as meta-bar.spec.js).
+async function poseAsRealVisitor(page) {
+  await page.addInitScript(() =>
+    Object.defineProperty(navigator, 'webdriver', { get: () => false })
+  );
+}
+
+test.describe('Popular commands — record opens', () => {
+  test('does NOT record opens in automated browsers (CI / bots)', async ({ page }) => {
+    const state = await mockBackends(page);
+    await page.goto('/'); // navigator.webdriver is true under Playwright
+    await page.locator('.tile').first().click();
+    await expect(page.locator('#modal')).toBeVisible();
+    await page.waitForTimeout(500);
+
+    expect(state.opens.length).toBe(0);
+  });
+
+  test('records one open with the command_id (real visitor)', async ({ page }) => {
+    await poseAsRealVisitor(page);
+    const state = await mockBackends(page);
+    await page.goto('/');
+
+    const tile = page.locator('.tile').first();
+    const name = await tile.locator('.tile-name').innerText();
+    await tile.click();
+    await expect(page.locator('#modal')).toBeVisible();
+    await page.waitForTimeout(500);
+
+    expect(state.opens.length).toBe(1);
+    // command_id is `${cls}:${name}` — it must contain the command name
+    expect(state.opens[0]).toMatch(/^[^:]+:.+/); // `${cls}:${name}` shape
+    expect(state.opens[0]).toContain(name);
+  });
+
+  test('records each command at most once per session', async ({ page }) => {
+    await poseAsRealVisitor(page);
+    const state = await mockBackends(page);
+    await page.goto('/');
+
+    const tile = page.locator('.tile').first();
+    await tile.click();
+    await page.locator('#btn-close').click();
+    await tile.click(); // second open of the same command
+    await page.waitForTimeout(500);
+
+    expect(state.opens.length).toBe(1);
+  });
+});

--- a/tests/popular-commands.spec.js
+++ b/tests/popular-commands.spec.js
@@ -118,3 +118,55 @@ test.describe('Popular commands — record opens', () => {
     expect(state.opens.length).toBe(1);
   });
 });
+
+test.describe('Popular commands — badge + filter', () => {
+  // Returns the flat list of { id, name } for every command, in render order.
+  async function allCommands(page) {
+    return page.evaluate(() =>
+      window.categories.flatMap((c) =>
+        c.items.map((i) => ({ id: `${c.cls}:${i.name}`, name: i.name }))
+      )
+    );
+  }
+
+  test('badges only the popular commands (top ~10% with views)', async ({ page }) => {
+    const state = await mockBackends(page);
+    await page.goto('/');
+    const cmds = await allCommands(page);
+
+    // Give 20 commands views → top 10% = ceil(2.0) = 2 popular tiles.
+    state.rows = cmds.slice(0, 20).map((c, i) => ({ command_id: c.id, view_count: 20 - i }));
+    await page.reload();
+
+    await expect(page.locator('.tile-popular')).toHaveCount(2);
+  });
+
+  test('🔥 Popular filter shows popular commands, most-viewed first', async ({ page }) => {
+    const state = await mockBackends(page);
+    await page.goto('/');
+    const cmds = await allCommands(page);
+
+    state.rows = cmds.slice(0, 20).map((c, i) => ({ command_id: c.id, view_count: 20 - i }));
+    await page.reload();
+    // Wait for the async loadCounts().then(render) to paint badges before filtering.
+    await page.locator('.tile-popular').first().waitFor();
+
+    await page.getByRole('button', { name: '🔥 Popular' }).click();
+
+    const names = await page.locator('.tile .tile-name').allInnerTexts();
+    expect(names.length).toBe(2); // ceil(20 * 0.1)
+    expect(names[0]).toBe(cmds[0].name); // highest view_count first
+  });
+
+  test('no badges and page still works when counts fail to load', async ({ page }) => {
+    await mockBackends(page, { offline: true });
+    await page.goto('/');
+    // The command_views route aborts immediately, so loadCounts() rejects and
+    // the only render is the first (empty-popular) one — wait for the network
+    // to settle rather than guessing a timeout.
+    await page.waitForLoadState('networkidle');
+
+    expect(await page.locator('.tile-popular').count()).toBe(0);
+    expect(await page.locator('.tile').count()).toBeGreaterThan(10);
+  });
+});


### PR DESCRIPTION
## Summary

Makes the existing Supabase visitor-counter infrastructure do double duty: count how often each command's modal is opened and surface the most popular ones in the UI.

- **🔥 Popular badge** on the most-opened command tiles.
- **🔥 Popular filter** (next to ⭐ Start Here) showing popular commands, most-viewed first.

## How it works

- **Backend** (`supabase/`): new `command_views` table keyed by `command_id`, an atomic `increment_command_view(cmd_id)` upsert RPC, and read-only RLS. A dedicated Edge Function `increment-command-view` performs the write with the service-role key (validates the `command_id`). Mirrors the `increment-visitor` pattern exactly.
- **Client** (`js/popular-commands.js`): reads all counts via REST with the publishable anon key; writes go **only** through the Edge Function. `commandId(item)` = `${cls}:${name}` is the stable per-command key (the data has no ids). `app.js` records an open from `openModal()` and re-renders once `loadCounts()` resolves.
- **Counting**: once per session per command (`sessionStorage` guard) and **never for automated browsers** (`navigator.webdriver`), so CI/bots don't inflate counts — same model as the visitor counter.
- **"Popular" = top ~10%** of commands with at least one view, ranked by count.
- **Fails gracefully**: a Supabase outage leaves the page fully usable — no badges, no console errors.

## Deploy steps required (Supabase dashboard)

These backend files don't auto-apply to the live project:

1. Run `supabase/migrations/0002_command_views.sql` in the SQL editor (or `supabase db push`).
2. Deploy the Edge Function: `supabase functions deploy increment-command-view` (or create it in the dashboard with that exact slug). No secrets needed — `SUPABASE_URL` / `SUPABASE_SERVICE_ROLE_KEY` are injected automatically.

Until both are applied, the feature is a graceful no-op.

## Test plan

- [x] `npm test` — full suite green (291 passed; new feature spec runs across chromium, iPhone 16, Pixel 7)
- [x] `npm run lint` — clean
- New `tests/popular-commands.spec.js` covers: bot-skip, single record, once-per-session, command_id shape, badge count (top 10%), filter ordering (most-viewed-first), and offline graceful-degradation. All Supabase traffic mocked via `page.route` (no real writes).

## Notes

- Design spec and implementation plan are included under `docs/superpowers/`.
- Known minor edges (by design): grouped view doesn't preserve the view-count sort; your own just-recorded open isn't badged until the next page load.
