### PR TITLE
Added new commands

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -68,6 +68,11 @@ Accessibility→accessibility, Patterns→pattern, CLI→cli.
 it — the tile renders, the modal works, and syntax highlighting applies
 automatically (see below). All `Item` fields are required.
 
+**No em-dashes or en-dashes in command data.** Never use `—` (em-dash) or `–`
+(en-dash) in any `Item` field (`name`, `desc`, `tip`, `code`, etc.). Use a period,
+comma, or colon to break a sentence, and a hyphen `-` for ranges (e.g. `200-299`).
+This is enforced by `data-integrity.spec.js`, so a stray dash fails the test suite.
+
 **To add a new category:** create `js/data/<name>.js` exporting a `Category`, then
 import and add it to the array in `js/data/index.js`. Add a matching tile-gradient
 rule `.<cls> { … }` and (if you want it in the modal token theme) nothing else is

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -239,6 +239,7 @@ await page.addInitScript(() => { Object.defineProperty(navigator, 'webdriver', {
 - **Semicolons:** required
 - **Trailing commas:** ES5 style
 - **Line length:** ~100 chars (Prettier enforced)
+- **No em-dashes or en-dashes in command data.** Never use `—` (em-dash) or `–` (en-dash) in any `js/data/` item field (`name`, `desc`, `tip`, `code`, etc.). Use a period, comma, or colon to break a sentence, and a hyphen `-` for ranges (e.g. `200-299`). `data-integrity.spec.js` enforces this — a stray dash fails the suite.
 - **ESLint globals:** each block (app, test, supabase functions) has its own globals whitelist in `eslint.config.js` — add new globals there if needed
 
 ---

--- a/js/data/actions.js
+++ b/js/data/actions.js
@@ -174,4 +174,19 @@ await page.locator('#custom-input').dispatchEvent('change');
 await page.locator('#drop-zone').dispatchEvent('drop', {
   dataTransfer: await page.evaluateHandle(() => new DataTransfer())
 });`},
+
+{name:'mouse.move()',
+ level:'advanced',
+ desc:'Low-level pointer control: mouse.move(), mouse.down(), mouse.up(), and mouse.wheel() drive raw mouse input at absolute coordinates. Use when dragTo() cannot model the interaction: canvas drawing, custom drag-and-drop libraries, or scroll gestures.',
+ tip:'Coordinates are viewport pixels, so combine with boundingBox() to target an element reliably. Prefer dragTo() for ordinary drag-and-drop; drop to mouse.* only for fine-grained sequences.',
+ docs:'https://playwright.dev/docs/api/class-mouse#mouse-move',
+ code:`// Manual drag sequence (down -> move in steps -> up)
+const box = await page.locator('#canvas').boundingBox();
+await page.mouse.move(box.x + 10, box.y + 10);
+await page.mouse.down();
+await page.mouse.move(box.x + 120, box.y + 80, { steps: 10 });
+await page.mouse.up();
+
+// Scroll the page with the wheel (deltaX, deltaY)
+await page.mouse.wheel(0, 600);`},
 ]};

--- a/js/data/api.js
+++ b/js/data/api.js
@@ -165,4 +165,39 @@ await page.route('**/api/items', handler);
 
 // Remove the mock and real requests will now go through
 await page.unroute('**/api/items', handler);`},
+
+{name:'context.route()',
+ level:'intermediate',
+ desc:'Intercepts network requests for every page in the browser context, not just a single page. Ideal for rules that should apply suite-wide: blocking analytics, injecting auth headers, or mocking third-party scripts.',
+ tip:'Set it in a fixture or beforeEach so the rule also covers pages opened later (popups, new tabs). page.route() affects one page; context.route() affects them all.',
+ docs:'https://playwright.dev/docs/api/class-browsercontext#browser-context-route',
+ code:`test('blocks analytics across the whole context', async ({ page, context }) => {
+  // Applies to this page AND any page opened later in the context
+  await context.route('**/analytics/**', route => route.abort());
+
+  // Inject a header on every API call from any page
+  await context.route('**/api/**', route => {
+    route.continue({
+      headers: { ...route.request().headers(), 'x-test': 'pw' },
+    });
+  });
+
+  await page.goto('/dashboard');
+});`},
+
+{name:'routeFromHAR()',
+ level:'advanced',
+ desc:'Replays network responses from a previously recorded HAR file, serving them as mocks. Record real traffic once, then run tests against the captured responses, with no manual route.fulfill() needed.',
+ tip:'Record with update: true (or the CLI: npx playwright open --save-har=api.har), commit the HAR, then replay with update: false in CI. Use the url option to stub only matching requests and let the rest hit the network.',
+ docs:'https://playwright.dev/docs/api/class-page#page-route-from-har',
+ code:`// Replay recorded responses (default mode)
+await page.routeFromHAR('fixtures/api.har', {
+  url: '**/api/**',     // only stub API calls
+  update: false,        // replay, don't re-record
+});
+
+// Re-record the HAR from live traffic (run once to refresh fixtures)
+await page.routeFromHAR('fixtures/api.har', { update: true });
+
+await page.goto('/dashboard');`},
 ]};

--- a/js/data/assertions.js
+++ b/js/data/assertions.js
@@ -221,7 +221,7 @@ await expect(page.locator('.chart')).toHaveScreenshot('chart.png', {
 
 {name:'toBeOK()',
  level:'intermediate',
- desc:'Asserts that an API response has a status code in the 2xx range (200–299). Use with APIRequestContext.',
+ desc:'Asserts that an API response has a status code in the 2xx range (200-299). Use with APIRequestContext.',
  tip:'The quickest sanity-check for API tests. Combine with response.json() to also validate the response body shape.',
  docs:'https://playwright.dev/docs/api/class-apiresponseassertions#api-response-assertions-to-be-ok',
  code:`const response = await request.get('/api/users');

--- a/js/data/config.js
+++ b/js/data/config.js
@@ -193,4 +193,28 @@ export default defineConfig({
 // In tests
 await page.getByTestId('submit-btn').click();
 // Finds: <button data-cy="submit-btn">`},
+
+{name:'projects (dependencies)',
+ level:'advanced',
+ desc:'A project can declare dependencies on other projects that must run first, plus a teardown project that runs after it finishes. This is the modern, recommended way to handle auth: a "setup" project logs in and saves storageState before the test projects run.',
+ tip:'Preferred over globalSetup for auth. The setup step shows up in the report and trace, can use fixtures, and reruns on retry. Point dependent projects at the saved storageState via use.',
+ docs:'https://playwright.dev/docs/test-projects#dependencies',
+ code:`// playwright.config.ts
+export default defineConfig({
+  projects: [
+    // 1. Runs first: logs in and saves auth state to a file
+    { name: 'setup', testMatch: /global\\.setup\\.ts/ },
+
+    // 2. Depends on 'setup'; starts already authenticated
+    {
+      name: 'chromium',
+      use: { ...devices['Desktop Chrome'], storageState: 'auth.json' },
+      dependencies: ['setup'],
+      teardown: 'cleanup',
+    },
+
+    // 3. Runs after everything that names it as teardown
+    { name: 'cleanup', testMatch: /global\\.teardown\\.ts/ },
+  ],
+});`},
 ]};

--- a/js/data/patterns.js
+++ b/js/data/patterns.js
@@ -133,7 +133,7 @@ test('user can log in', async ({ page }) => {
 {name:'storageState auth',
  level:'intermediate',
  desc:'Saves authenticated browser state (cookies, localStorage) to a file and reuses it across tests, eliminating repeated UI logins.',
- tip:'Run the login once in a global setup file and save the state. Set storageState in playwright.config.ts so every test starts already logged in.',
+ tip:'This globalSetup approach still works, but the modern recommended pattern is a dedicated "setup" project that other projects list in dependencies. It shows up in reports and traces and reruns on retry. See "projects (dependencies)" in the Config category.',
  docs:'https://playwright.dev/docs/auth#basic-shared-account-in-all-tests',
  code:`// global-setup.ts, runs once before all tests
 import { chromium } from '@playwright/test';

--- a/js/data/setup.js
+++ b/js/data/setup.js
@@ -251,4 +251,55 @@ test('user can log in', async ({ loginPage }) => {
   await loginPage.login('user@test.com', 'secret');
   await expect(loginPage.welcomeMessage).toBeVisible();
 });`},
+
+{name:'test() tags',
+ level:'intermediate',
+ desc:'Attaches one or more tags to a test or describe block via the { tag } option. Tags let you slice the suite at runtime with --grep / --grep-invert. Added in Playwright 1.42.',
+ tip:'Tag names must start with @. Use tags like @smoke, @slow, @vrt to run subsets, e.g. a fast smoke gate in CI. Run with: npx playwright test --grep @smoke.',
+ docs:'https://playwright.dev/docs/test-annotations#tag-tests',
+ code:`// Tag a single test
+test('login', { tag: ['@smoke', '@fast'] }, async ({ page }) => {
+  await page.goto('/login');
+});
+
+// Tag an entire describe block
+test.describe('Reports', { tag: '@slow' }, () => {
+  test('exports CSV', async ({ page }) => { /* ... */ });
+});
+
+// Run only smoke tests:  npx playwright test --grep @smoke
+// Skip slow tests:       npx playwright test --grep-invert @slow`},
+
+{name:'test.describe.configure()',
+ level:'intermediate',
+ desc:'Controls the execution mode and retries for the tests in a file or describe block. mode: "serial" runs them in order and stops on the first failure; mode: "parallel" runs them concurrently even when fullyParallel is off; "default" restores normal behaviour.',
+ tip:'Use mode: "serial" only when tests genuinely depend on each other (e.g. a multi-step wizard). A failure skips the rest. Prefer isolated parallel tests everywhere else. You can also set a per-block retries count.',
+ docs:'https://playwright.dev/docs/api/class-test#test-describe-configure',
+ code:`// Run every test in this file in order; stop on first failure
+test.describe.configure({ mode: 'serial' });
+
+// Or scope it to a single describe block
+test.describe('Checkout wizard', () => {
+  test.describe.configure({ mode: 'serial', retries: 2 });
+
+  test('step 1: add to cart', async ({ page }) => { /* ... */ });
+  test('step 2: pay',         async ({ page }) => { /* ... */ });
+});
+
+// mode: 'parallel' forces concurrency even if fullyParallel is off`},
+
+{name:'test.describe.skip() / fixme()',
+ level:'intermediate',
+ desc:'Skips or marks-as-broken an entire describe block in one call, instead of annotating every test inside. skip() drops the whole group; fixme() flags it as a known-failing group that is not run.',
+ tip:'Reach for the describe-level variant when a whole feature is unavailable on a browser/environment or is temporarily broken. Far cleaner than adding test.skip() to every test in the block.',
+ docs:'https://playwright.dev/docs/api/class-test#test-describe-skip',
+ code:`// Skip a whole group unconditionally
+test.describe.skip('Beta dashboard', () => {
+  test('shows widgets', async ({ page }) => { /* ... */ });
+});
+
+// Mark a whole group as broken (known failure, not run)
+test.describe.fixme('Legacy export', () => {
+  test('downloads PDF', async ({ page }) => { /* ... */ });
+});`},
 ]};

--- a/tests/data-integrity.spec.js
+++ b/tests/data-integrity.spec.js
@@ -161,6 +161,29 @@ test.describe('Data integrity', () => {
     });
     expect(invalid).toEqual([]);
   });
+
+  test('no field contains an em-dash or en-dash (use periods, commas, or hyphens)', async ({
+    page,
+  }) => {
+    const offenders = await page.evaluate(() => {
+      const fields = ['name', 'level', 'desc', 'tip', 'docs', 'code'];
+      const bad = [];
+      categories.forEach(cat => {
+        cat.items.forEach(item => {
+          fields.forEach(field => {
+            const value = item[field];
+            if (typeof value !== 'string') return;
+            if (value.includes('—'))
+              bad.push(`"${item.name}" in "${cat.cat}" has an em-dash in "${field}"`);
+            if (value.includes('–'))
+              bad.push(`"${item.name}" in "${cat.cat}" has an en-dash in "${field}"`);
+          });
+        });
+      });
+      return bad;
+    });
+    expect(offenders).toEqual([]);
+  });
 });
 
 test.describe('test.info() entry', () => {


### PR DESCRIPTION
🔴 Missing Entirely (high-value additions)
1. Test Tags — add to setup.js
The { tag: '@smoke' } / { tag: ['@fast', '@vrt'] } syntax (added v1.42) is nowhere in the cheat sheet. The --grep @tag CLI flag is covered, but tagging tests themselves isn't. Extremely common in real-world suites.

test('login', { tag: ['@smoke', '@fast'] }, async ({ page }) => { ... });
test.describe('Reports', { tag: '@slow' }, () => { ... });
2. test.describe.configure() — add to setup.js
{ mode: 'serial' } is only mentioned as a one-line code comment inside the fullyParallel config entry. The full API ('serial', 'parallel', 'default') for controlling intra-file test ordering deserves its own entry.

3. context.route() — add to api.js
Only page.route() is covered. Context-level routing applies to all pages in the browser context — the standard way to block analytics, inject auth headers globally, or mock third-party scripts across an entire test.

test('...', async ({ page, context }) => {
  await context.route('**/analytics/**', r => r.abort());
4. page.mouse API — add to actions.js
dragTo() is covered, but page.mouse.move() / mouse.down() / mouse.up() / mouse.wheel() are missing. Needed for canvas drawing, fine-grained drag sequences, custom DnD libraries that dragTo() can't handle, and scroll gestures.

5. page.routeFromHAR() — add to api.js
Playwright's HAR record-and-replay feature is completely absent. It's a unique, powerful capability: record real network traffic once and replay it as mocks in future runs — no manual route.fulfill() needed.

await page.routeFromHAR('fixtures/api.har', { update: false });
6. Project dependencies / teardown — add to config.js
The modern recommended auth pattern uses project-level dependencies: ['setup'] + a setup project that saves storageState. The globalSetup approach shown in the existing storageState auth pattern is the older way. This is a significant gap given how central auth is to real test suites.

🟡 Needs Updating
storageState auth pattern (patterns.js) — The example uses the global-setup.ts + globalSetup config approach. Playwright now recommends the project dependencies approach for this. Worth noting the modern alternative or replacing the example.