### PR TITLE
Automated Playwright doc-sync action and new commands

### DIFF
--- a/.github/cheatsheet-sync.mcp.json
+++ b/.github/cheatsheet-sync.mcp.json
@@ -1,0 +1,11 @@
+{
+  "mcpServers": {
+    "context7": {
+      "type": "http",
+      "url": "https://mcp.context7.com/mcp",
+      "headers": {
+        "CONTEXT7_API_KEY": "${CONTEXT7_API_KEY}"
+      }
+    }
+  }
+}

--- a/.github/prompts/cheatsheet-sync.md
+++ b/.github/prompts/cheatsheet-sync.md
@@ -2,11 +2,18 @@
 
 You are running headless in GitHub Actions. Your job is to keep this repo's
 command data (`js/data/*.js`) accurate against the **current** Playwright release
-and open a **pre-validated pull request** with any fixes. You never merge.
+and open a **pre-validated pull request** with any fixes.
 
-Read and obey `CLAUDE.md` and `AGENTS.md` in full — they define the data schema,
-the "all fields required" rule, the Context7 accuracy rule, and the **no
-em-dash / en-dash rule**. Everything below is the task on top of those rules.
+**You never merge, and never push to `master` or `develop`.** Every change goes
+through a pull request that the maintainer (Nigel) reviews and merges manually.
+Do not enable auto-merge, do not approve your own PR, and do not bypass branch
+protection. Your output is always a PR awaiting human approval, nothing more.
+
+Read and obey `CLAUDE.md`, `AGENTS.md`, and `README.md` in full — they define the
+data schema, the "all fields required" rule, the Context7 accuracy rule, the **no
+em-dash / en-dash rule**, and the contributor conventions for adding commands.
+Any new command you add must follow the "Adding a New Command" guidance in
+`README.md` and `AGENTS.md`. Everything below is the task on top of those rules.
 
 ## Authoritative source: Context7 (not your training data)
 
@@ -20,7 +27,8 @@ If Context7 is unavailable or rate-limited, stop: log the failure and exit
 
 ## Steps
 
-1. Read `package.json`, every file in `js/data/`, `CLAUDE.md`, and `AGENTS.md`.
+1. Read `package.json`, every file in `js/data/`, `CLAUDE.md`, `AGENTS.md`, and
+   `README.md`.
 2. Determine the **latest stable** Playwright version (via Context7 / npm).
    Note the version currently pinned as `@playwright/test` in `package.json`.
 3. For each documented command, verify against the current docs:
@@ -37,6 +45,31 @@ If Context7 is unavailable or rate-limited, stop: log the failure and exit
    version, bump the `@playwright/test` devDependency in `package.json` to it in
    this same PR, so the version badge, the dependency, and the documented
    behavior stay consistent.
+6. **Keep the documentation consistent.** If your changes warrant it, update the
+   docs in the same PR so nothing drifts:
+   - On a version bump, update every hardcoded Playwright version reference,
+     including the **version badge in `README.md`** and the **version line in
+     `CLAUDE.md`**, to match `package.json`.
+   - If you add a command in a way that affects documented examples, category
+     lists, or counts in `README.md`, `AGENTS.md`, or `CLAUDE.md`, update those
+     too. (The live command count in the app is computed automatically, so it
+     needs no manual edit.)
+   - Make only the documentation changes that your data changes actually require.
+     Do not rewrite or restructure the docs beyond that.
+7. **Add or update tests for what you change.** Tests live in `tests/`.
+   - The generic checks in `data-integrity.spec.js` already validate every
+     entry's schema, level, docs URL, and the no-dash rule, so a plain new entry
+     needs no extra test.
+   - When you add a **notable** new command or change an existing feature in a
+     way worth pinning down, add or update a **targeted** test, following the
+     existing per-entry pattern (see the `test.info() entry` block in
+     `data-integrity.spec.js`): assert the entry exists in the right category,
+     has the expected `level`, and that its `code` covers the key API.
+   - When you change an existing entry that a test already asserts on, update
+     that test so it matches the new behavior.
+   - Keep tests meaningful: do not add redundant tests that merely duplicate the
+     generic schema checks, and do not weaken or delete a failing assertion just
+     to make it pass.
 
 ## Hard rules for any edit
 
@@ -47,11 +80,14 @@ If Context7 is unavailable or rate-limited, stop: log the failure and exit
 - `level` is one of `beginner` | `intermediate` | `advanced`.
 - `docs` URLs must start with `https://` and point to `playwright.dev`.
 - Do **not** rename categories, change `cls`/`color`, restructure files, mass-add
-  every new API, or touch the highlighter, UI, or tests.
+  every new API, or touch the highlighter or UI. You **may** add or update
+  targeted tests in `tests/` for the entries you change (see step 7), but do not
+  restructure the test suite or alter unrelated tests.
 
 ## Validate, then open the PR
 
-Run the project's own gates and only proceed on green:
+Run the project's own gates and only proceed on green. This includes any tests
+you added or updated in step 7 — they are part of the gate, not optional:
 
 ```bash
 npm run lint
@@ -76,9 +112,14 @@ changed:
      body must list **every** change (what and why, with the Playwright version),
      a "New entries added" section, and a "Suggested follow-ups" section for
      anything you chose not to include.
-- **`DRY_RUN` is `false` but lint or tests fail and you cannot fix them:** open
-  the PR as a **draft** with `gh pr create --draft`, and put the failing command
-  output in the PR body. Never open a non-draft PR that is not green. Never merge.
+- **`DRY_RUN` is `false` but lint or tests fail and you cannot legitimately fix
+  them:** the PR must be **flagged, not hidden**. Open it as a **draft**
+  (`gh pr create --draft`), prefix the title with `[CI FAILING]`, add the
+  `ci-failing` label if available (`gh pr edit --add-label ci-failing`, ignore if
+  the label does not exist), and paste the full failing `npm run lint` / `npm test`
+  output into the PR body under a "Failing checks" heading. Never open a non-draft
+  PR when lint or tests are red, never silence a failure by weakening a test, and
+  never merge. A human decides what to do with a flagged PR.
 
 ## Bot identity for commits
 

--- a/.github/prompts/cheatsheet-sync.md
+++ b/.github/prompts/cheatsheet-sync.md
@@ -1,0 +1,88 @@
+# Task: sync the Playwright cheat sheet with current Playwright
+
+You are running headless in GitHub Actions. Your job is to keep this repo's
+command data (`js/data/*.js`) accurate against the **current** Playwright release
+and open a **pre-validated pull request** with any fixes. You never merge.
+
+Read and obey `CLAUDE.md` and `AGENTS.md` in full — they define the data schema,
+the "all fields required" rule, the Context7 accuracy rule, and the **no
+em-dash / en-dash rule**. Everything below is the task on top of those rules.
+
+## Authoritative source: Context7 (not your training data)
+
+Verify every claim against the live Playwright docs through the Context7 MCP
+server. Resolve the library id for `/microsoft/playwright`, then query the docs
+for each command you inspect. Do **not** rely on memory for signatures,
+deprecations, or URLs — that is the entire reason Context7 is wired in.
+
+If Context7 is unavailable or rate-limited, stop: log the failure and exit
+**without** opening a low-confidence PR. A wrong PR is worse than no PR.
+
+## Steps
+
+1. Read `package.json`, every file in `js/data/`, `CLAUDE.md`, and `AGENTS.md`.
+2. Determine the **latest stable** Playwright version (via Context7 / npm).
+   Note the version currently pinned as `@playwright/test` in `package.json`.
+3. For each documented command, verify against the current docs:
+   - Is it **deprecated** or removed? If deprecated, keep the entry but note it
+     in `tip` and point to the replacement. If fully removed, replace it with the
+     current equivalent rather than deleting outright.
+   - Has the **signature / behavior** changed? Update `desc` / `code` / `tip`.
+   - Is the `docs` URL **broken or moved**? Fix it (must be a real
+     `https://playwright.dev/...` URL).
+4. Identify a **small** number (roughly 1-5) of **genuinely high-value new
+   commands** introduced in recent releases that fit an existing category, and
+   add them as new entries. Be conservative: quality over coverage.
+5. **Version bump:** if the latest stable Playwright is newer than the pinned
+   version, bump the `@playwright/test` devDependency in `package.json` to it in
+   this same PR, so the version badge, the dependency, and the documented
+   behavior stay consistent.
+
+## Hard rules for any edit
+
+- Follow the exact data shape used by surrounding entries (compact object
+  literal; all of `name`, `level`, `desc`, `tip`, `docs`, `code` present).
+- **No em-dashes (—) or en-dashes (–)** in any field. Use periods, commas, or
+  colons to break sentences, and a hyphen `-` for ranges.
+- `level` is one of `beginner` | `intermediate` | `advanced`.
+- `docs` URLs must start with `https://` and point to `playwright.dev`.
+- Do **not** rename categories, change `cls`/`color`, restructure files, mass-add
+  every new API, or touch the highlighter, UI, or tests.
+
+## Validate, then open the PR
+
+Run the project's own gates and only proceed on green:
+
+```bash
+npm run lint
+npm test
+```
+
+Behavior depends on the `DRY_RUN` environment variable and on whether anything
+changed:
+
+- **No changes at all:** exit 0. Do not create a branch or PR.
+- **`DRY_RUN` is `true`:** do **not** create a branch, commit, or PR. Write a
+  clear summary of the proposed changes and the full `git diff` to the GitHub
+  Actions **job summary** (`$GITHUB_STEP_SUMMARY`), then exit 0.
+- **`DRY_RUN` is `false` and lint + tests pass:**
+  1. Create a branch named `bot/cheatsheet-sync-<YYYY-MM-DD>`.
+  2. Before creating it, check for an existing **open** PR whose head branch
+     starts with `bot/cheatsheet-sync-`; if one exists, update that branch
+     instead of stacking a duplicate.
+  3. Commit as the bot identity with a Conventional Commit message
+     (e.g. `chore: sync cheat sheet with Playwright vX.Y.Z`).
+  4. Push and open a PR against the default branch with `gh pr create`. The PR
+     body must list **every** change (what and why, with the Playwright version),
+     a "New entries added" section, and a "Suggested follow-ups" section for
+     anything you chose not to include.
+- **`DRY_RUN` is `false` but lint or tests fail and you cannot fix them:** open
+  the PR as a **draft** with `gh pr create --draft`, and put the failing command
+  output in the PR body. Never open a non-draft PR that is not green. Never merge.
+
+## Bot identity for commits
+
+```bash
+git config user.name  "github-actions[bot]"
+git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+```

--- a/.github/workflows/cheatsheet-sync.yml
+++ b/.github/workflows/cheatsheet-sync.yml
@@ -1,0 +1,70 @@
+name: Cheat sheet sync
+
+# Keeps js/data/ in sync with Playwright releases. Once a month (and on demand)
+# Claude Code reads the data, checks each command against the CURRENT Playwright
+# docs via the Context7 MCP server, and opens a pre-validated PR with any fixes.
+# It never merges. A no-drift run opens no PR. See the design spec in
+# docs/superpowers/specs/ and the task brief in .github/prompts/cheatsheet-sync.md.
+on:
+  schedule:
+    - cron: '0 6 1 * *' # 06:00 UTC on the 1st of each month (~Playwright cadence)
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: 'Scan and print the proposed diff to the job summary without opening a PR'
+        type: boolean
+        default: false
+
+# Least privilege: edit files on a branch and open a PR, nothing more.
+permissions:
+  contents: write
+  pull-requests: write
+
+concurrency:
+  group: cheatsheet-sync
+  cancel-in-progress: false
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          # Default GITHUB_TOKEN lets the agent push a branch. Supplying a PAT
+          # here instead also makes the existing Tests workflow run on the PR.
+          token: ${{ secrets.PAT || github.token }}
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Install Playwright browsers
+        run: npx playwright install --with-deps chromium webkit
+
+      - name: Run cheat sheet sync agent
+        uses: anthropics/claude-code-action@v1
+        env:
+          # Expanded inside .github/cheatsheet-sync.mcp.json as ${CONTEXT7_API_KEY}.
+          CONTEXT7_API_KEY: ${{ secrets.CONTEXT7_API_KEY }}
+          # Read by the agent to decide whether to open a PR. False on schedule.
+          DRY_RUN: ${{ github.event_name == 'workflow_dispatch' && inputs.dry_run }}
+          # gh pr create needs this; falls back to GITHUB_TOKEN when no PAT is set.
+          GH_TOKEN: ${{ secrets.PAT || github.token }}
+        with:
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          github_token: ${{ secrets.PAT || github.token }}
+          prompt: |
+            Follow the instructions in .github/prompts/cheatsheet-sync.md exactly.
+            The DRY_RUN environment variable controls whether you open a PR.
+          # Sonnet 4.6 is the cost-effective choice for a monthly doc sync.
+          # Switch --model to claude-opus-4-8 for maximum quality if desired.
+          claude_args: |
+            --model claude-sonnet-4-6
+            --max-turns 60
+            --mcp-config .github/cheatsheet-sync.mcp.json
+            --allowedTools Read,Edit,Write,Bash,mcp__context7

--- a/docs/superpowers/specs/2026-06-08-cheatsheet-sync-action-design.md
+++ b/docs/superpowers/specs/2026-06-08-cheatsheet-sync-action-design.md
@@ -1,0 +1,178 @@
+# Playwright Cheat Sheet Sync Action — Design
+
+**Date:** 2026-06-08
+**Status:** Approved
+
+## Goal
+
+Keep the cheat sheet data (`js/data/*.js`) accurate as Playwright ships new
+versions, deprecates methods, and changes signatures — without a human manually
+diffing the docs each release. A scheduled GitHub Action runs Claude Code with
+the Context7 MCP server (current Playwright docs) and opens a **pre-validated
+pull request** with the fixes for human review.
+
+This is a recurring maintenance task, so the value is in automating the tedious
+part (finding drift, drafting the edits) while keeping a human merge gate.
+
+## Constraints
+
+- The site is vanilla ES modules with **no build step**. The action only edits
+  data files, `package.json`, and runs the existing npm scripts; it introduces
+  no new runtime dependencies into the app.
+- **Never auto-merge.** The action opens a PR; a human reviews and merges. The
+  agent has no authority to push to `master`/`develop` directly.
+- **Every PR must be pre-validated.** The agent runs `npm run lint` and
+  `npm test` (the full Playwright suite, including `data-integrity.spec.js` and
+  its em-dash/en-dash guard) before opening a non-draft PR.
+- **The project's own rules govern the edits.** Claude Code auto-loads
+  `CLAUDE.md` and `AGENTS.md`; the data schema, "all fields required," the
+  Context7 accuracy rule, and the **no em-dash / en-dash rule** are therefore
+  already in the agent's context. The task prompt must not contradict them.
+- **Least-privilege CI.** The workflow requests only `contents: write` and
+  `pull-requests: write`.
+- **Bounded cost.** Pinned model + a `--max-turns` cap; ~12 scheduled runs/year;
+  a run that finds no drift opens no PR.
+
+## Decisions (settled during brainstorming)
+
+- **Output:** a pull request that edits the data files directly (not an issue,
+  not a comment). CI + human review are the safety net.
+- **Trigger:** monthly cron (`0 6 1 * *`, 06:00 UTC on the 1st) to match
+  Playwright's ~monthly cadence, plus `workflow_dispatch` for on-demand runs.
+  The manual trigger exposes a `dry_run` boolean input that performs the scan
+  and prints the proposed diff to the job summary **without** creating a PR.
+- **Scope:** correctness **plus** a small set of curated new entries. The agent
+  may:
+  - update `desc` / `tip` / `code` / `docs` for drift,
+  - mark deprecated methods (note in `tip`, keep the entry),
+  - repair broken or moved `docs` URLs,
+  - add a **few** genuinely high-value new commands from recent releases.
+
+  The agent must **not** mass-add every new API, restructure files, rename
+  categories, or change colors/`cls` values.
+- **Version target (the judgment call, confirmed by user):** the agent checks
+  the latest stable Playwright. If it is newer than the `@playwright/test`
+  version pinned in `package.json`, the **same PR bumps that devDependency** and
+  syncs the entries to that version, so the version badge (read from
+  `package.json`), the dependency, and the documented behavior stay consistent.
+  Plain dependency-only bumps remain Dependabot's responsibility; this PR bundles
+  the bump *with* the doc sync because they belong together.
+
+## Components
+
+### 1. `.github/workflows/cheatsheet-sync.yml`
+
+The workflow. Responsibilities:
+
+- Triggers: `schedule` (monthly cron) + `workflow_dispatch` (with `dry_run`).
+- `permissions: { contents: write, pull-requests: write }`.
+- A `concurrency` group so overlapping runs cannot race.
+- Steps: checkout (full history) → `setup-node@v4` (Node 20, npm cache) →
+  `npm ci` → `npx playwright install --with-deps chromium webkit` (the suite
+  needs browsers) → run `anthropics/claude-code-action@v1`.
+- The action receives:
+  - `prompt`: points at / inlines the task brief (see component 2),
+  - `claude_args`: `--mcp-config` (Context7, component 3), an allowed-tools list
+    (Bash, Edit/Write, Read, plus `gh`), `--max-turns`, and a pinned `--model`,
+  - `anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}`,
+  - `GH_TOKEN` / `GITHUB_TOKEN` in env so the agent can push a branch and run
+    `gh pr create`.
+- A commented-out hook for an optional `PAT` secret, used only if the user wants
+  `test.yml` to re-run on the bot's PR (see Gotchas).
+
+### 2. `.github/prompts/cheatsheet-sync.md`
+
+The agent's task brief, versioned and reviewable, kept out of the YAML. It
+describes only the *task and guardrails*, deferring conventions to
+`CLAUDE.md` / `AGENTS.md`:
+
+1. Read `package.json`, all `js/data/*.js`, `CLAUDE.md`, `AGENTS.md`.
+2. Determine the latest stable Playwright version (via Context7 / npm).
+3. For each documented command, use Context7 to verify it against the current
+   docs: deprecations, signature changes, moved/broken `docs` URLs.
+4. Identify a small number of high-value new commands worth adding.
+5. Apply edits following the project rules (schema, no em-dashes, accuracy).
+6. If the latest version is newer than the pin, bump `@playwright/test` in
+   `package.json`.
+7. Run `npm run lint` && `npm test`.
+   - On green: create a dated branch, commit (bot identity, conventional
+     message), push, and `gh pr create` with a summary of every change and a
+     "Suggested follow-ups" section.
+   - On failure it cannot resolve: open the PR as a **draft** explaining what
+     failed.
+   - In `dry_run` mode: skip branch/commit/PR; write the proposed diff and
+     findings to the job summary.
+8. If nothing changed: exit cleanly, open no PR.
+
+### 3. Context7 MCP config
+
+A small JSON passed via `claude_args --mcp-config` registering the remote
+Context7 server (`https://mcp.context7.com/mcp`). Reads
+`CONTEXT7_API_KEY` from secrets when present (higher rate limit) and works
+without it. Library target: `/microsoft/playwright`.
+
+## Data flow
+
+```
+cron (0 6 1 * *) | workflow_dispatch{dry_run}
+  └─ checkout (fetch-depth: 0)
+      └─ setup-node 20 + npm ci + playwright install chromium webkit
+          └─ claude-code-action@v1
+              prompt:  .github/prompts/cheatsheet-sync.md
+              mcp:     Context7 → /microsoft/playwright
+              tools:   Read, Edit/Write, Bash, gh
+              ├─ read data + package.json + CLAUDE.md + AGENTS.md
+              ├─ Context7: current API for target version
+              ├─ edit entries (+ bump package.json if newer)
+              ├─ npm run lint && npm test        ← hard gate
+              └─ green → branch+commit+push+`gh pr create`
+                 fail  → draft PR w/ explanation
+                 dry_run → job summary only, no PR
+                 no drift → exit 0, no PR
+```
+
+## Error handling & edge cases
+
+- **Tests fail and the agent cannot fix them:** open a **draft** PR documenting
+  the failing output; never a green-looking PR. Never merge.
+- **No drift found:** exit 0, no branch, no PR — a clean no-op run.
+- **Duplicate PRs:** dated branch name (`bot/cheatsheet-sync-YYYY-MM-DD`); the
+  agent checks for an existing open sync PR and updates rather than stacking
+  duplicates.
+- **Context7 unavailable / rate-limited:** the agent reports the failure in the
+  job log and exits without opening a low-confidence PR (no guessing from
+  memory — that is the whole reason Context7 is in the loop).
+- **Cost runaway:** `--max-turns` cap bounds a single run; `concurrency`
+  prevents pile-ups.
+- **Missing `ANTHROPIC_API_KEY`:** the action fails fast with a clear message;
+  until the secret is added the workflow simply errors on run (no silent
+  partial behavior).
+
+## Gotchas / prerequisites
+
+- **Repo secrets (added by the user, out of band):** `ANTHROPIC_API_KEY`
+  (required); `CONTEXT7_API_KEY` (optional); optional `PAT` for CI-on-PR.
+- **CI-on-PR:** PRs opened with the default `GITHUB_TOKEN` do **not** trigger
+  `test.yml`. This is acceptable because the sync job already runs the full
+  suite before opening the PR. If the user later wants `test.yml` to re-run on
+  the bot's PR too, switch the push/`gh` auth to the `PAT` secret (commented
+  hook left in the workflow).
+- **Branch protection:** the PR targets the default branch; merge stays manual.
+
+## Testing the workflow itself
+
+- A GitHub workflow cannot be unit-tested in the Playwright suite. Validation is
+  by **manual `workflow_dispatch` with `dry_run: true`** first: confirm the
+  agent reads the data, queries Context7, and prints a sensible proposed diff to
+  the job summary without opening a PR.
+- A second `dry_run: false` manual run confirms the end-to-end PR path
+  (branch → lint/test gate → `gh pr create`).
+- No change to the existing `data-integrity.spec.js` is required: it already
+  enforces the schema and dash rules that any agent-authored entry must pass.
+
+## Out of scope
+
+- Auto-merging PRs.
+- Documenting non-Playwright libraries.
+- Restructuring categories, the highlighter, or the UI.
+- Replacing Dependabot for routine dependency bumps unrelated to doc drift.

--- a/docs/superpowers/specs/2026-06-08-cheatsheet-sync-action-design.md
+++ b/docs/superpowers/specs/2026-06-08-cheatsheet-sync-action-design.md
@@ -19,8 +19,10 @@ part (finding drift, drafting the edits) while keeping a human merge gate.
 - The site is vanilla ES modules with **no build step**. The action only edits
   data files, `package.json`, and runs the existing npm scripts; it introduces
   no new runtime dependencies into the app.
-- **Never auto-merge.** The action opens a PR; a human reviews and merges. The
-  agent has no authority to push to `master`/`develop` directly.
+- **Never auto-merge.** The action opens a PR; the **maintainer (Nigel)** reviews
+  and merges it manually. The agent has no authority to push to `master` /
+  `develop`, approve its own PR, enable auto-merge, or bypass branch protection.
+  Its output is always a PR awaiting human approval.
 - **Every PR must be pre-validated.** The agent runs `npm run lint` and
   `npm test` (the full Playwright suite, including `data-integrity.spec.js` and
   its em-dash/en-dash guard) before opening a non-draft PR.
@@ -46,10 +48,21 @@ part (finding drift, drafting the edits) while keeping a human merge gate.
   - update `desc` / `tip` / `code` / `docs` for drift,
   - mark deprecated methods (note in `tip`, keep the entry),
   - repair broken or moved `docs` URLs,
-  - add a **few** genuinely high-value new commands from recent releases.
+  - add a **few** genuinely high-value new commands from recent releases,
+    following the "Adding a New Command" guidance in `README.md` / `AGENTS.md`,
+  - update documentation in the same PR when the data changes require it:
+    hardcoded Playwright version references (the `README.md` version badge and
+    the `CLAUDE.md` version line) on a bump, plus any category lists or examples
+    in `README.md` / `AGENTS.md` / `CLAUDE.md` affected by the change,
+  - add or update **targeted** tests in `tests/` for notable new commands or
+    changed features, following the existing per-entry pattern (the
+    `test.info() entry` block in `data-integrity.spec.js`). Plain new entries
+    need no extra test because the generic schema/dash checks already cover them.
 
   The agent must **not** mass-add every new API, restructure files, rename
-  categories, or change colors/`cls` values.
+  categories, change colors/`cls` values, rewrite docs beyond what the data
+  change requires, restructure the test suite, or weaken a failing assertion to
+  make it pass.
 - **Version target (the judgment call, confirmed by user):** the agent checks
   the latest stable Playwright. If it is newer than the `@playwright/test`
   version pinned in `package.json`, the **same PR bumps that devDependency** and
@@ -86,7 +99,7 @@ The agent's task brief, versioned and reviewable, kept out of the YAML. It
 describes only the *task and guardrails*, deferring conventions to
 `CLAUDE.md` / `AGENTS.md`:
 
-1. Read `package.json`, all `js/data/*.js`, `CLAUDE.md`, `AGENTS.md`.
+1. Read `package.json`, all `js/data/*.js`, `CLAUDE.md`, `AGENTS.md`, `README.md`.
 2. Determine the latest stable Playwright version (via Context7 / npm).
 3. For each documented command, use Context7 to verify it against the current
    docs: deprecations, signature changes, moved/broken `docs` URLs.
@@ -121,9 +134,9 @@ cron (0 6 1 * *) | workflow_dispatch{dry_run}
               prompt:  .github/prompts/cheatsheet-sync.md
               mcp:     Context7 → /microsoft/playwright
               tools:   Read, Edit/Write, Bash, gh
-              ├─ read data + package.json + CLAUDE.md + AGENTS.md
+              ├─ read data + package.json + CLAUDE.md + AGENTS.md + README.md
               ├─ Context7: current API for target version
-              ├─ edit entries (+ bump package.json if newer)
+              ├─ edit entries (+ bump package.json + sync version in docs if newer)
               ├─ npm run lint && npm test        ← hard gate
               └─ green → branch+commit+push+`gh pr create`
                  fail  → draft PR w/ explanation
@@ -133,8 +146,13 @@ cron (0 6 1 * *) | workflow_dispatch{dry_run}
 
 ## Error handling & edge cases
 
-- **Tests fail and the agent cannot fix them:** open a **draft** PR documenting
-  the failing output; never a green-looking PR. Never merge.
+- **Tests fail and the agent cannot legitimately fix them:** the PR is **flagged,
+  not hidden** — opened as a **draft** with a `[CI FAILING]` title prefix, a
+  `ci-failing` label (if it exists), and the full failing `npm run lint` /
+  `npm test` output in the body under a "Failing checks" heading. Never a
+  green-looking non-draft PR, never silence a failure by weakening a test, never
+  merge. The agent's own added/updated tests are part of this gate. A human
+  decides what to do with a flagged PR.
 - **No drift found:** exit 0, no branch, no PR — a clean no-op run.
 - **Duplicate PRs:** dated branch name (`bot/cheatsheet-sync-YYYY-MM-DD`); the
   agent checks for an existing open sync PR and updates rather than stacking


### PR DESCRIPTION
## Summary

Three related pieces of work to keep the cheat sheet accurate as Playwright evolves:

1. **New commands** added to the cheat sheet (the founded content gaps).
2. **A "no em-dash" rule** — now documented *and* enforced by the test suite.
3. **An automated monthly sync GitHub Action** that uses Claude Code + Context7
   to detect Playwright drift and open a pre-validated PR for review.

## 1. New command entries

| Category | Added |
|----------|-------|
| Setup    | `test() tags`, `test.describe.configure()`, `test.describe.skip() / fixme()` |
| API      | `context.route()`, `routeFromHAR()` |
| Action   | `mouse.move()` (low-level move/down/up/wheel) |
| Config   | `projects (dependencies)` (modern setup-project auth) |

Also updated the `storageState auth` pattern tip to point at the modern
project-dependencies approach.

## 2. Automated sync action

- `.github/workflows/cheatsheet-sync.yml` — runs **monthly (cron) and on manual
  dispatch only**; no push/merge trigger.
- `.github/prompts/cheatsheet-sync.md` — the agent's task brief.
- `.github/cheatsheet-sync.mcp.json` — Context7 MCP config.
- Design spec: `docs/superpowers/specs/2026-06-08-cheatsheet-sync-action-design.md`.

The agent reads `CLAUDE.md` / `AGENTS.md` / `README.md`, verifies each command
against current docs via Context7, fixes drift, adds a few high-value new
commands, bumps the Playwright version (and its doc references) when newer, then
runs `npm run lint && npm test` before opening a PR.

**Requires repo secrets:** `ANTHROPIC_API_KEY` and `CONTEXT7_API_KEY` (both added).

### Safety
- PRs are **never auto-merged** — every change requires manual approval to reach
  `master`. The agent cannot push to `master`/`develop` or approve its own PR.
- First run should use the manual `dry_run: true` option (scan + diff to the job
  summary, no PR).

## Testing

- `npm run lint` ✅
- `npm test` ✅ — 97 passed, 3 skipped (includes the new em-dash guard).
