### PR TITLE
Expand --repeat-each with flakiness detection combined-flag patterns

### DIFF
--- a/js/data/cli.js
+++ b/js/data/cli.js
@@ -142,7 +142,7 @@ npx playwright test --fully-parallel --workers=4
 {name:'--repeat-each',
  level:'intermediate',
  desc:'Runs every test a specified number of times in a single run. Useful for detecting flaky tests that fail intermittently.',
- tip:'Use --workers=1 during flakiness runs — parallel workers can mask race conditions between iterations. Once the test is stable, scale workers back up.',
+ tip:'Use --workers=1 during flakiness runs. Parallel workers can mask race conditions between iterations. Once the test is stable, scale workers back up.',
  docs:'https://playwright.dev/docs/test-cli#reference',
  code:`npx playwright test --repeat-each=10
 # Run every test 10 times

--- a/js/data/cli.js
+++ b/js/data/cli.js
@@ -142,13 +142,25 @@ npx playwright test --fully-parallel --workers=4
 {name:'--repeat-each',
  level:'intermediate',
  desc:'Runs every test a specified number of times in a single run. Useful for detecting flaky tests that fail intermittently.',
- tip:'Combine with --reporter=html to easily spot which iterations failed. Start with 10 runs to surface common flakiness.',
+ tip:'Use --workers=1 during flakiness runs — parallel workers can mask race conditions between iterations. Once the test is stable, scale workers back up.',
  docs:'https://playwright.dev/docs/test-cli#reference',
  code:`npx playwright test --repeat-each=10
 # Run every test 10 times
 
-npx playwright test -g "checkout" --repeat-each=5
-# Repeat a specific test 5 times to check for flakiness`},
+# Isolate a specific test and repeat it
+npx playwright test -g "checkout flow" --repeat-each=10
+
+# Safer flaky detection: single worker prevents race conditions between runs
+npx playwright test --repeat-each=10 --workers=1 path/to/your.spec.ts
+
+# Watch the test run to spot visual flakiness
+npx playwright test --repeat-each=10 --headed path/to/your.spec.ts
+
+# Generate an HTML report to see which iterations failed
+npx playwright test --repeat-each=10 --workers=1 --reporter=html
+
+# Target one browser only
+npx playwright test --repeat-each=10 --project=chromium path/to/your.spec.ts`},
 
 {name:'--max-failures',
  level:'intermediate',


### PR DESCRIPTION
## Summary

The existing `--repeat-each` entry covered only basic usage. This expands the code example with the most useful real-world combinations for flakiness detection.

### Changes to `js/data/cli.js`

**Before:** 2 code examples (basic repeat, repeat with `-g`)

**After:** 6 examples covering the full flakiness-detection workflow:

| Example | Why it matters |
|---------|---------------|
| `--repeat-each=10 -g "test name"` | Isolate one test before repeating |
| `--repeat-each=10 --workers=1` | Single worker prevents race conditions masking the flake |
| `--repeat-each=10 --headed` | Watch the browser to spot visual/timing failures |
| `--repeat-each=10 --workers=1 --reporter=html` | Rich report showing exactly which iterations failed |
| `--repeat-each=10 --project=chromium` | Target a specific browser |

**Tip updated** to call out `--workers=1` as the key best practice (parallel workers can hide race conditions between iterations).

## Test plan
- [x] CI passes — no schema changes, just an expanded code string

https://claude.ai/code/session_01PaU8q812n3VsdqJWQpwy4L

---
_Generated by [Claude Code](https://claude.ai/code/session_01PaU8q812n3VsdqJWQpwy4L)_