### PR TITLE
Add expect.configure() to the Assertions cheat sheet

### DIFF
--- a/js/data/assertions.js
+++ b/js/data/assertions.js
@@ -355,4 +355,17 @@ await expect(async () => {
   const body = await res.json();
   expect(body.ready).toBe(true);
 }).toPass({ timeout: 10000, intervals: [1000, 2000, 5000] });`},
+
+{name:'expect.configure()',
+ level:'advanced',
+ desc:'Creates a pre-configured expect instance with its own defaults such as timeout and soft, so you avoid repeating those options on every assertion.',
+ tip:'Configure once, then reuse the returned function everywhere. Great for a longer timeout on a slow page, or a soft expect that records failures without stopping the test.',
+ docs:'https://playwright.dev/docs/test-assertions#expectconfigure',
+ code:`// Reuse a longer timeout without repeating it on every assertion
+const slowExpect = expect.configure({ timeout: 10_000 });
+await slowExpect(page.getByText('Submit')).toBeVisible();
+
+// Reuse soft assertions without .soft on every call
+const softExpect = expect.configure({ soft: true });
+await softExpect(page.getByText('Submit')).toBeVisible();`},
 ]};

--- a/tests/cheatsheet.spec.js
+++ b/tests/cheatsheet.spec.js
@@ -423,9 +423,10 @@ test.describe('New assertion tiles', () => {
     'toMatchObject()',
     'toBeGreaterThan()',
     'expect().toPass()',
+    'expect.configure()',
   ];
 
-  test('all 9 new assertion commands are rendered as tiles', async ({ page }) => {
+  test('all 10 new assertion commands are rendered as tiles', async ({ page }) => {
     await page.locator('.filter-btn', { hasText: 'Assertions' }).click();
     for (const name of newAssertions) {
       await expect(

--- a/tests/data-integrity.spec.js
+++ b/tests/data-integrity.spec.js
@@ -296,6 +296,42 @@ test.describe('pageErrors() entry', () => {
   });
 });
 
+test.describe('expect.configure() entry', () => {
+  test('expect.configure() exists in the Assertions category', async ({ page }) => {
+    const found = await page.evaluate(() => {
+      const assertions = categories.find(c => c.cat === 'Assertions');
+      return assertions ? assertions.items.some(i => i.name === 'expect.configure()') : false;
+    });
+    expect(found).toBe(true);
+  });
+
+  test('expect.configure() has level advanced', async ({ page }) => {
+    const level = await page.evaluate(() => {
+      const assertions = categories.find(c => c.cat === 'Assertions');
+      return assertions?.items.find(i => i.name === 'expect.configure()')?.level;
+    });
+    expect(level).toBe('advanced');
+  });
+
+  test('expect.configure() docs URL points to the expectconfigure section', async ({ page }) => {
+    const docs = await page.evaluate(() => {
+      const assertions = categories.find(c => c.cat === 'Assertions');
+      return assertions?.items.find(i => i.name === 'expect.configure()')?.docs ?? '';
+    });
+    expect(docs).toBe('https://playwright.dev/docs/test-assertions#expectconfigure');
+  });
+
+  test('expect.configure() code covers timeout and soft defaults', async ({ page }) => {
+    const code = await page.evaluate(() => {
+      const assertions = categories.find(c => c.cat === 'Assertions');
+      return assertions?.items.find(i => i.name === 'expect.configure()')?.code ?? '';
+    });
+    expect(code).toContain('expect.configure(');
+    expect(code).toContain('timeout');
+    expect(code).toContain('soft');
+  });
+});
+
 test.describe('Reorganized categories', () => {
   // Helper: return the list of category names that contain a command.
   const homesOf = (page, name) =>


### PR DESCRIPTION
## What

Adds a new `expect.configure()` entry to the **Assertions** category. It was
missing from the cheat sheet despite being a useful helper for reducing
repetition in assertions.

`expect.configure()` creates a pre-configured `expect` instance with its own
defaults (e.g. `timeout`, `soft`), so you configure once and reuse it instead
of repeating the option on every assertion.

## Details

- New entry in `js/data/assertions.js`, grouped with the other `expect.*`
  helpers (`expect.soft()`, `expect.poll()`, `expect().toPass()`).
- Level: `advanced`. Docs link points to the official
  [`#expectconfigure`](https://playwright.dev/docs/test-assertions#expectconfigure)
  section (verified).
- Code example mirrors the recommended pattern: a reusable `slowExpect` with a
  `timeout` default and a `softExpect` with `soft: true`.

## Tests

- `tests/cheatsheet.spec.js` — added `expect.configure()` to the assertion-tile
  list (renamed "all 9" → "all 10"), covering tile render + modal.
- `tests/data-integrity.spec.js` — added a dedicated `expect.configure() entry`
  block asserting it exists in Assertions, has level `advanced`, has the correct
  docs URL, and its code covers both `timeout` and `soft`.

## Verification

- `npm test` — 441 passed, 6 skipped (pre-existing), all 3 projects.
- `npm run lint` — clean.
- Follows project conventions: no em/en-dashes in data, single quotes, compact
  data-file style, no new dependencies or build step.
