### PR TITLE
Add locator chaining & evaluation methods (audit vs. "20 Locator Methods")

### DIFF
--- a/js/data/queries.js
+++ b/js/data/queries.js
@@ -168,4 +168,30 @@ const row = page.getByRole('row')
   .filter({ hasText: 'John' })
   .describe('Johns table row');
 await row.getByRole('button', { name: 'Delete' }).click();`},
+
+{name:'locator.locator()',
+ level:'intermediate',
+ desc:'Chains from an existing locator to find elements inside it. Scopes the search to the descendants of the current locator, keeping selectors short and resilient.',
+ tip:"Chain locators to narrow down within a container instead of writing one long selector. Use ':scope > ' for direct children only, and 'xpath=..' to step up to the parent (Playwright has no parent() method).",
+ docs:'https://playwright.dev/docs/api/class-locator#locator-locator',
+ code:`// Find an input inside a specific form
+await page.locator('form#signup').locator('input[name=email]').fill('a@b.com');
+
+// Direct children only, via :scope
+const topLevel = page.locator('ul.menu').locator(':scope > li');
+
+// Step up to the parent element (there is no parent() method)
+const row = page.getByText('Total').locator('xpath=..');`},
+
+{name:'locator.getByRole()',
+ level:'intermediate',
+ desc:'Runs a getByRole query (or any getBy* method) scoped to the descendants of an existing locator instead of the whole page.',
+ tip:'Every getBy* method (getByRole, getByText, getByLabel, and so on) also exists on a locator. Scope them to a container to target the right element when the same role appears many times on the page.',
+ docs:'https://playwright.dev/docs/api/class-locator#locator-get-by-role',
+ code:`// Click the "Delete" button inside one specific card
+const card = page.getByRole('listitem').filter({ hasText: 'Invoice #42' });
+await card.getByRole('button', { name: 'Delete' }).click();
+
+// Scope a link search to the navigation only
+const links = await page.locator('nav').getByRole('link').allTextContents();`},
 ]};

--- a/js/data/utility.js
+++ b/js/data/utility.js
@@ -642,6 +642,35 @@ expect(tags).toContain('Playwright');
 // allInnerTexts() returns only visible rendered text
 const labels = await page.locator('li').allInnerTexts();`},
 
+{name:'locator.evaluate()',
+ level:'advanced',
+ desc:'Runs a JavaScript function in the browser with the matched element passed as the first argument, then returns the result to the test.',
+ tip:'Use to read DOM properties or call element methods that Playwright does not expose directly. The function runs in the page, so pass any test-side values as the second argument.',
+ docs:'https://playwright.dev/docs/api/class-locator#locator-evaluate',
+ code:`// Read a DOM property straight off the element
+const width = await page.locator('#box').evaluate(el => el.offsetWidth);
+
+// Pass an argument from the test into the browser context
+await page.locator('#box').evaluate((el, color) => {
+  el.style.background = color;
+}, 'red');`},
+
+{name:'locator.evaluateAll()',
+ level:'advanced',
+ desc:'Runs a JavaScript function once with an array of ALL matched elements passed in, then returns the result to the test.',
+ tip:'Use to compute a value across every matching element in a single browser round-trip. Unlike locator.all(), the callback receives raw DOM elements, not locators.',
+ docs:'https://playwright.dev/docs/api/class-locator#locator-evaluate-all',
+ code:`// Collect the text of every list item in one call
+const texts = await page.locator('li').evaluateAll(
+  els => els.map(el => el.textContent.trim())
+);
+
+// Assert every nav link points to an https URL
+const allHttps = await page.locator('nav a').evaluateAll(
+  els => els.every(el => el.href.startsWith('https://'))
+);
+expect(allHttps).toBe(true);`},
+
 {name:'waitForFunction()',
  level:'advanced',
  desc:'Waits until a JavaScript expression evaluated in the browser returns a truthy value.',


### PR DESCRIPTION
## Summary

Audited the cheat sheet against the **"20 Playwright Locator Methods"** reference. **14 of 20** were already present; this PR adds the **4 genuinely missing real methods**.

### Already covered (no change)
`page.locator()`, `getByText()`, `getByRole()`, `getByLabel()`, `getByPlaceholder()`, `filter()`, `first()`, `last()`, `nth()`, `and()`, `or()` (Query) + `locator.count()`, `locator.all()`, `locator.allTextContents()` (Utility).

### Added

| Method | Category | Level | Covers reference # |
|--------|----------|-------|--------------------|
| `locator.locator()` | Query | intermediate | #12 chaining, #13 `:scope >` direct children, #14 parent |
| `locator.getByRole()` | Query | intermediate | #15 scoped `getBy*` chaining |
| `locator.evaluate()` | Utility | advanced | #19 |
| `locator.evaluateAll()` | Utility | advanced | #20 |

### ⚠️ Note on `locator.parent()` (reference #14)

The infographic lists `locator.parent()`, but **this is not a native Playwright API** — verified against the official docs via Context7. There is no `.parent()` method. The correct parent-selection approach, `locator('xpath=..')`, is documented **inside** the `locator.locator()` entry instead of adding a non-existent method with a fabricated docs link.

## Test plan
- [x] Replicated every `data-integrity.spec.js` assertion in Node against the real loaded modules — all pass (required fields, level enum, docs URLs, code length, no duplicate names, **no em/en dashes**)
- [x] All 4 new items load and are present (267 total items)
- [x] `eslint js/` passes
- [x] Modules parse as valid ES modules
- [x] CI (`test.yml`) green on chromium + webkit

https://claude.ai/code/session_01PaU8q812n3VsdqJWQpwy4L

---
_Generated by [Claude Code](https://claude.ai/code/session_01PaU8q812n3VsdqJWQpwy4L)_